### PR TITLE
Fixed invalid reference to oscal-m3 in config script

### DIFF
--- a/scripts/include/common-environment.sh
+++ b/scripts/include/common-environment.sh
@@ -66,7 +66,7 @@ if [ -z ${METASCHEMA_SCRIPT_INIT+x} ]; then
   initialize_defaults() {
     # set meaningful defaults if not set by local configuration
     if [ -z ${PROVIDER_DIR+x} ]; then
-      PROVIDER_DIR="${METASCHEMA_SCRIPT_DIR}/../toolchains/oscal-m3"
+      PROVIDER_DIR="${METASCHEMA_SCRIPT_DIR}/../toolchains/oscal-m2"
     fi
 
     if [ -z ${WORKING_DIR+x} ]; then


### PR DESCRIPTION
# Committer Notes

Quick fix to adjust broken path in the CI/CD config script.