### PR TITLE
Addressing emergent bug in markdown conversion, M3 release

### DIFF
--- a/toolchains/oscal-m2/json/md-oscal-converter.xsl
+++ b/toolchains/oscal-m2/json/md-oscal-converter.xsl
@@ -324,7 +324,8 @@
     <xsl:template match="m:replace" expand-text="true">
         <xsl:param name="str" as="xs:string"/>
         <!--<xsl:value-of>replace({$str},{@match},{string(.)})</xsl:value-of>-->
-        <xsl:sequence select="replace($str, @match, string(.))"/>
+<!-- 's' sets dot-matches-all       -->
+        <xsl:sequence select="replace($str, @match, string(.),'s')"/>
         <!--<xsl:copy-of select="."/>-->
     </xsl:template>
 
@@ -461,6 +462,8 @@
     
      <xsl:variable name="examples" xml:space="preserve">
         <p>**Markdown** and even " quoted text" and **more markdown**</p>
+         <p>**See the FedRAMP Documents page under Key Cloud Service Provider (CSP) Documents> Vulnerability Scanning Requirements** ([https://www.FedRAMP.gov/documents/](https://www.FedRAMP.gov/documents/))</p>
+         <p>**See the FedRAMP Documents page under Key Cloud Service Provider\n\t\t\t\t\t\t\t\t(CSP) Documents> Vulnerability Scanning Requirements** ([https://www.FedRAMP.gov/documents/](https://www.FedRAMP.gov/documents/))</p>
         <p>
 
 Just a plain old \* star, and another \* ...


### PR DESCRIPTION
# Committer Notes

Addresses emergent markdown conversion bug, where inline tagging was failing due to 'innocuous' whitespace including new lines.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?
