### PR TITLE
Metaschema comparison logic developed for OSCAL M3 delivery

### DIFF
--- a/toolchains/xslt-proto-v04/compare/abstract-dataset.xsl
+++ b/toolchains/xslt-proto-v04/compare/abstract-dataset.xsl
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    
+    expand-text="true"
+    exclude-result-prefixes="#all"
+    version="3.0">
+    
+    <xsl:param name="collection" as="xs:string"/>
+    
+    <xsl:variable name="everything" as="document-node()">
+        <xsl:sequence select="document($collection)"/>
+    </xsl:variable>
+    
+    <xsl:template match="/" name="xsl:initial-template">
+        <root name="#root">
+            <xsl:call-template name="handle-children">
+                <xsl:with-param name="whose" select="$everything"/>
+            </xsl:call-template>
+        </root>
+    </xsl:template>
+    
+    <xsl:key name="all-named" match="* | @* | text()" use="m:nodename(.)"/>
+    
+    <xsl:function name="m:nodename" as="xs:string">
+        <xsl:param name="who"/>
+        <xsl:variable name="what" select="if ($who/self::element()) then 'e#' else if ($who/self::attribute()) then 'a#' else ()"/>
+        <xsl:sequence select="$what || $who/(node-name(),'#text')[1]"/>        
+    </xsl:function>
+    
+    <!-- $whose is always a like-named set of nodes -->
+    <xsl:template name="handle-children">
+        <xsl:param name="whose"   select="()"/>
+        <xsl:variable name="whose-name" select="m:nodename($whose[1])"/>
+            <xsl:for-each-group select="$whose/(* | @* | text()[matches(.,'\S')])"
+                group-by="m:nodename(.)">
+                <n name="{current-grouping-key()}" count="{count(current-group())}"
+                    >
+                    <xsl:if test="exists(current-group()/(* | text()))">
+                        <xsl:attribute name="significantly-ordered" select="count(current-group()[m:significantly-ordered(.)])"/>
+                    </xsl:if>
+                <xsl:call-template name="handle-children">
+                    <xsl:with-param name="whose" select="current-group()"/>
+                </xsl:call-template>
+                </n>
+            </xsl:for-each-group>
+    </xsl:template>
+    
+    <!-- Returns true if an element contains children who names suggest a significant order -->
+    <xsl:function name="m:significantly-ordered" as="xs:boolean">
+      <xsl:param name="who" as="element()"/>
+      <xsl:sequence select="some $c in ($who/(*|text())) satisfies
+            exists(m:recaller($c))"/>
+    </xsl:function>
+    
+    <!-- For any node, retrieves sibling nodes of the same name, when nodes of any other name intervene -->
+    <xsl:function name="m:recaller" as="node()*">
+        <xsl:param name="who" as="node()"/>
+        <xsl:variable name="named" select="m:nodename($who)"/>
+        <xsl:sequence select="$who/(following-sibling::*|following-sibling::text()[matches(.,'\S')])[not(m:nodename(.)=$named)]/
+            (following-sibling::*|following-sibling::text()[matches(.,'\S')])[m:nodename(.)=$named]"/>
+    </xsl:function>
+</xsl:stylesheet>

--- a/toolchains/xslt-proto-v04/compare/analyze-abstract-tree.xsl
+++ b/toolchains/xslt-proto-v04/compare/analyze-abstract-tree.xsl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    xmlns="http://www.w3.org/1999/xhtml"
+    
+    expand-text="true"
+    xpath-default-namespace="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    exclude-result-prefixes="#all"
+    version="3.0">
+    
+    
+    
+    <xsl:template match="/" >
+        <html>
+            <style type="text/css">
+
+body > * {{ margin-top: 1ex }}
+details {{ padding: 0.5ex; border: thin solid black; margin-top: 0.5ex }}
+
+            </style>
+               <xsl:apply-templates/>
+        </html>
+    </xsl:template>
+    
+    <xsl:template match="root" priority="5">
+        <body>
+            <xsl:variable name="body-contents">
+          <xsl:for-each-group select="//n" group-by="@name">
+              <xsl:variable name="t" select="substring-before(current-grouping-key(),'#')"/>
+              <xsl:variable name="type" select="if ($t='e') then 'Element' else if ($t='a') then 'Attribute' else 'Text'"/>
+              <div>
+                  <h3>{ $type }{ $type[not(.='Text')] ! (': ' || substring-after(current-grouping-key(),'#')) } </h3>
+                  <p class="parents" data-count="{sum(current-group()/@count)}"
+                      data-type-count="{ current-group()/../@name => distinct-values() => count() }">Parents <xsl:call-template name="list-parents">
+                      <xsl:with-param name="who" select="current-group()"/>
+                  </xsl:call-template></p>
+                  <xsl:if test="$t = 'e'">
+                      <p class="children" data-count="{sum(current-group()/n/@count)}"
+                          data-type-count="{ current-group()/n/@name => distinct-values() => count() }">Children <xsl:call-template name="list">
+                          <xsl:with-param name="who" select="current-group()/n"/>
+                      </xsl:call-template></p>
+                  </xsl:if>
+              </div>
+              
+          </xsl:for-each-group>
+            </xsl:variable>
+            <div class="summary" xsl:xpath-default-namespace="http://www.w3.org/1999/xhtml">
+                <xsl:variable name="node-count" select="count($body-contents/div)"/>
+                <xsl:variable name="parent-count" select="sum($body-contents/div/p[@class='parents']/@data-type-count)"/>
+                <p>Declared node type count: { $node-count} </p>
+                <p>Parentage rate (is the number of parents defined for nodes, divided by the number of nodes): { $parent-count }/{ $node-count } = 
+                    { $parent-count div $node-count }. Its upper limit is the node type count (if everything is allowed inside everything); its lower limit is 1 (no node has more than one parent type).</p>          
+                <p>Parentage quotient is the parentage rate, divided again by the count of declared node types: { $parent-count }/({ $node-count }*{$node-count}) = {  $parent-count div ($node-count * $node-count) }. Its upper limit is 1 (if everything is allowed inside everything) and lower limit, the reciprocal of the node type count (so, approach zero for many node types). This is a rough measure of 'model entropy', characteristic of more generic and free-form models -- whereas ordered models would have more prescribed structures.</p>
+            </div>
+            <xsl:sequence select="$body-contents"/>
+        </body>
+    </xsl:template>
+    
+    <xsl:template name="list-parents">
+        <xsl:param name="who" as="node()*"/>
+        <xsl:text>: </xsl:text>
+        <xsl:for-each select="$who">
+            <xsl:if test="not(position() eq 1)">, </xsl:if>
+            <xsl:value-of select="parent::n/@name => substring-after('#')"/>
+        <xsl:text> ({ @count })</xsl:text>
+        </xsl:for-each>
+    </xsl:template>
+    
+    <xsl:template name="list">
+        <xsl:param name="who" as="node()*"/>
+        <!--<xsl:value-of select="distinct-values($who/substring-after(@name,'#'))" separator=", "/>-->
+        <xsl:text> ({ if (empty($who)) then 'none' else count(distinct-values($who/@name)) })</xsl:text>
+        <xsl:if test="exists($who)">: </xsl:if>
+        <xsl:for-each-group select="$who" group-by="@name">
+            <xsl:if test="not(position() eq 1)">, </xsl:if>
+            <xsl:value-of select="current-grouping-key() => substring-after('#')"/>
+        </xsl:for-each-group>
+    </xsl:template>
+    
+    <xsl:function name="m:definitions" as="element()*">
+        <xsl:param name="metaschema" as="element(METASCHEMA)"/>
+        <xsl:sequence select="$metaschema/(define-assembly | define-field | define-flag)"/>
+    </xsl:function>
+    
+    <!--high entropy count p/c is close to (c*c) 
+      <a b="n">
+          <a b="n">
+              <b>
+                  <a>
+                      <b></b>
+                  </a>
+              </b>
+          </a>
+      </a>
+    
+    low entropy count p/c is close to count c, p/c^2 is low depending on c (no of children)
+    <bob>
+        <jim>
+            <jane>
+                <bill></bill>
+                <joe></joe>
+            </jane>
+        </jim>
+        <mark>
+            <mary></mary>
+        </mark>
+    </bob>
+    -->
+    <!--
+
+    absolute count of object types (element|attribute names)
+    where { p/c } is a set of p/c instances
+      extant parent/child
+      or permissible via schema
+    count(p) / count(c)*count(c)
+    
+    larger schemas address greater semantic complexity
+    but do not always provide advantages
+    paradoxically they can be difficult to extend and adapt
+    also, problem of 'many ways to do things' is not solved
+      by having more ways to do things
+    
+    for every a/b pair, how many have a b/a pair?
+    how many a permit a//a?
+    -->
+</xsl:stylesheet>

--- a/toolchains/xslt-proto-v04/compare/analyze-metaschema.xsl
+++ b/toolchains/xslt-proto-v04/compare/analyze-metaschema.xsl
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    xmlns="http://www.w3.org/1999/xhtml"
+    
+    expand-text="true"
+    xpath-default-namespace="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    exclude-result-prefixes="#all"
+    version="3.0">
+    
+    
+    
+    <xsl:template match="/" >
+        <html>
+            <style type="text/css">
+
+body > * {{ margin-top: 1ex }}
+details {{ padding: 0.5ex; border: thin solid black; margin-top: 0.5ex }}
+
+            </style>
+               <xsl:apply-templates/>
+        </html>
+    </xsl:template>
+    
+    <xsl:template match="METASCHEMA" priority="5">
+        <body>
+          <xsl:apply-templates/>
+        </body>
+    </xsl:template>
+    
+    <xsl:function name="m:definitions" as="element()*">
+        <xsl:param name="metaschema" as="element(METASCHEMA)"/>
+        <xsl:sequence select="$metaschema/(define-assembly | define-field | define-flag)"/>
+    </xsl:function>
+    
+    <!--high entropy count p/c is close to (c*c) 
+      <a b="n">
+          <a b="n">
+              <b>
+                  <a>
+                      <b></b>
+                  </a>
+              </b>
+          </a>
+      </a>
+    
+    low entropy count p/c is close to count c, p/c^2 is low depending on c (no of children)
+    <bob>
+        <jim>
+            <jane>
+                <bill></bill>
+                <joe></joe>
+            </jane>
+        </jim>
+        <mark>
+            <mary></mary>
+        </mark>
+    </bob>
+    -->
+    <!--
+
+    absolute count of object types (element|attribute names)
+    where { p/c } is a set of p/c instances
+      extant parent/child
+      or permissible via schema
+    count(p) / count(c)*count(c)
+    
+    larger schemas address greater semantic complexity
+    but do not always provide advantages
+    paradoxically they can be difficult to extend and adapt
+    also, problem of 'many ways to do things' is not solved
+      by having more ways to do things
+    
+    for every a/b pair, how many have a b/a pair?
+    how many a permit a//a?
+    -->
+</xsl:stylesheet>

--- a/toolchains/xslt-proto-v04/compare/compare-metaschemas.xsl
+++ b/toolchains/xslt-proto-v04/compare/compare-metaschemas.xsl
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    xmlns="http://www.w3.org/1999/xhtml"
+    
+    expand-text="true"
+    xpath-default-namespace="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    exclude-result-prefixes="#all"
+    version="3.0">
+    
+    <xsl:param as="xs:string" name="new-label">[new]</xsl:param>
+    <xsl:param as="xs:string" name="old-label">[old]</xsl:param>
+    
+    <xsl:variable name="new.label"><b class="new label">{ $new-label }</b></xsl:variable>
+    <xsl:variable name="old.label"><b class="old label">{ $old-label }</b></xsl:variable>
+    
+    <xsl:template match="/" >
+        <html>
+            <style type="text/css">
+
+body > * {{ margin-top: 1ex }}
+details {{ padding: 0.5ex; border: thin solid black; margin-top: 0.5ex }}
+
+.brief {{ font-size: smaller; border: thin solid black; padding: 1ex }}
+
+.changed {{ background-color: pink }}
+.new     {{ background-color: lemonchiffon }}
+
+.same h4 {{ display: none }}
+
+
+.label {{ font-family: sans-serif; font-weight: bold; font-size: 80% }}
+
+            </style>
+               <xsl:apply-templates/>
+        </html>
+    </xsl:template>
+    
+    <xsl:template match="compare" priority="5">
+        <xsl:variable name="METASCHEMA1" select="METASCHEMA[1]"/>
+        <body>
+        <xsl:apply-templates select="$METASCHEMA1">
+            <xsl:with-param tunnel="true" name="comparand" select="METASCHEMA except $METASCHEMA1"/>
+        </xsl:apply-templates>
+        </body>
+    </xsl:template>
+    
+    <xsl:function name="m:definitions" as="element()*">
+        <xsl:param name="metaschema" as="element(METASCHEMA)"/>
+        <xsl:sequence select="$metaschema/(define-assembly | define-field | define-flag)"/>
+    </xsl:function>
+    
+    <!-- Matches only top-level declarations -->
+    <xsl:key name="correspondents-by-name"
+        match="METASCHEMA/define-assembly | METASCHEMA/define-flag | METASCHEMA/define-field" use="@name">
+        
+    </xsl:key>
+    <xsl:template match="METASCHEMA">
+        <xsl:param tunnel="true" name="comparand" as="element(METASCHEMA)"/>
+        <xsl:variable name="new" select="."/>
+        <xsl:variable name="old" select="$comparand"/>
+        
+        <div class="summary">
+            <p class="brief">Comparing { short-name}:{ schema-version } ('{ $new.label }') with {$comparand ! (short-name || ':' || schema-version) } ('{ $old.label }') </p>
+            <xsl:for-each-group group-by="true()" select="m:definitions($old)[not(@name=m:definitions($new)/@name)]">
+                <div>
+                    <h5>Found in { $old.label} not { $new.label }: { string-join(current-group()/@name,', ')} </h5>
+                </div>
+            </xsl:for-each-group>
+            <xsl:for-each-group group-by="true()" select="m:definitions($new)[not(@name=m:definitions($old)/@name)]">
+                <div>
+                    <h5>Found in { $new.label} not { $old.label}: { string-join(current-group()/@name,', ')} </h5>
+                </div>
+            </xsl:for-each-group>
+            <xsl:for-each-group group-by="true()" select="$old/define-assembly">
+                <div>
+                    <h5>Assemblies in { $old.label}: { string-join(current-group()/(root-name,use-name,@name)[1],' ') } </h5>
+                </div>
+            </xsl:for-each-group>
+            <xsl:for-each-group group-by="true()" select="$new/define-assembly">
+                <div>
+                    <h5>Assemblies in { $new.label}: { string-join(current-group()/(root-name,use-name,@name)[1],' ')} </h5>
+                </div>
+            </xsl:for-each-group>
+            <xsl:for-each-group group-by="true()" select="($old | $new)/define-assembly">
+                <div>
+                    <h5>Assemblies in either/both: { string-join(distinct-values( current-group()/(root-name,use-name,@name)[1]), ' ')} </h5>
+                </div>
+            </xsl:for-each-group>
+            
+            <xsl:apply-templates/>
+        </div>
+    </xsl:template>
+    
+    <xsl:template match="METASCHEMA/*"/>
+    
+    <xsl:template priority="2" match="METASCHEMA/schema-name | METASCHEMA/short-name">
+        <p class="{local-name()}">
+            <xsl:apply-templates/>
+        </p>
+    </xsl:template>
+    
+    <xsl:key name="global-by-name" match="define-assembly | define-field | define-flag" use="@name"/>
+    
+    <xsl:template match="define-flag" priority="2">
+        <xsl:param tunnel="true" name="comparand" as="element(METASCHEMA)"/>
+        <xsl:variable name="me" select="."/>
+        <xsl:variable name="partner" select="$comparand/key('global-by-name',$me/@name,.)" as="element()?"/>
+        <xsl:variable name="new.sig" select="m:signature($me)"/>
+        <xsl:variable name="old.sig" select="$partner/m:signature(.)"/>
+        <xsl:variable name="status">
+            <xsl:choose>
+                <xsl:when test="empty($partner)">new</xsl:when>
+                <xsl:when test="$new.sig = $old.sig">same</xsl:when>
+                <xsl:otherwise>changed</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <details id="flag_{@name}" class="matched-{count($partner)} { $status }">
+            <summary><code>{ @name }</code>: { formal-name } { @as-type ! (' as type ' || .) } </summary>
+ 
+        </details>
+    </xsl:template>
+    
+    <xsl:template match="define-assembly | define-field" priority="2">
+        <xsl:param tunnel="true" name="comparand" as="element(METASCHEMA)"/>
+        <xsl:variable name="me" select="."/>
+        <xsl:variable name="partner" select="$comparand/key('global-by-name',$me/@name,.)" as="element()?"/>
+        <xsl:variable name="new.sig" select="m:signature($me)"/>
+        <xsl:variable name="old.sig" select="$partner/m:signature(.)"/>
+        <xsl:variable name="status">
+            <xsl:choose>
+                <xsl:when test="empty($partner)">new</xsl:when>
+                <xsl:when test="$new.sig = $old.sig">same</xsl:when>
+                <xsl:otherwise>changed</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <details id="assembly_{@name}" class="matched-{count($partner)} { $status }">
+            <summary><code>{ @name }</code>: { formal-name } { @as-type ! (' with value type ' || .) } </summary>
+            
+            <div>
+                <div class="comparison">
+                    <xsl:if test="exists($partner)">
+                    <p class="was">
+                        <span class="label">{ $old.label } flag{ if (count($partner/flag) eq 1) then '' else 's' }: </span>
+                        <xsl:apply-templates select="$partner/flag">
+                            <xsl:with-param name="partner" select="$me" tunnel="true"/>
+                        </xsl:apply-templates>
+                        <xsl:if test="empty($partner/flag)"> [none]</xsl:if>
+                    </p>
+                    </xsl:if>
+                    <p class="now">
+                        <span class="label">{ $new.label } flag{ if (count($me/flag) eq 1) then '' else 's' }: </span>
+                        <xsl:apply-templates select="$me/flag">
+                            <xsl:with-param name="partner" select="$partner" tunnel="true"/>
+                            <xsl:with-param name="tag-as" tunnel="true">**$1**</xsl:with-param>
+                        </xsl:apply-templates> 
+                        <xsl:if test="empty($me/flag)"> [none]</xsl:if>
+                    </p>
+                </div>
+                <xsl:for-each select="self::define-assembly">
+                        <div class="comparison">
+                            <xsl:if test="exists($partner)">
+                                <p class="was">
+                            <span class="label">{ $old.label } model: </span>
+                            <xsl:apply-templates select="$partner/model">
+                                <xsl:with-param name="partner" select="$me" tunnel="true"/>
+                            </xsl:apply-templates>
+                        </p>
+                            </xsl:if>
+                        <p class="now">
+                            <span class="label">{ $new.label } model: </span>
+                            <xsl:apply-templates select="$me/model">
+                                <xsl:with-param name="partner" select="$partner" tunnel="true"/>
+                                <xsl:with-param name="tag-as" tunnel="true">**$1**</xsl:with-param>
+                            </xsl:apply-templates>
+                        </p>
+                    </div>
+                </xsl:for-each>
+            </div>
+            <!--<xsl:apply-templates select="model"/>
+            <xsl:choose>
+                <xsl:when test="$status='new'"><h4>New in { $new.label }</h4></xsl:when>
+                <xsl:otherwise>
+                    <h4>{ $old.label } signature: <code class="sig old">{ $old.sig }</code></h4>
+                    <h4>{ $new.label } signature: <code class="sig old">{ $old.sig }</code></h4>
+                </xsl:otherwise>
+            </xsl:choose>-->
+            
+        </details>
+    </xsl:template>
+    
+    <xsl:template match="model">
+             <xsl:apply-templates/>
+    </xsl:template>
+    
+    <xsl:template priority="5" match="model//choice">
+        (<i>A choice:</i>
+                <xsl:apply-templates/>
+            )
+    </xsl:template>
+    
+    <xsl:template match="model//* | flag">
+        <xsl:param tunnel="true" name="partner" select="()"/>
+        <xsl:param tunnel="true" name="tag-as" select="'*$1*'"/>
+        <xsl:variable name="n" select="@ref | @name"/>
+        <xsl:variable name="tagged-name" as="xs:string">
+            <xsl:choose>
+                <xsl:when test="empty($partner//*[(@name | @ref) = $n])">
+                    <xsl:sequence select="replace($n, '^(.+)$', $tag-as)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:sequence select="string($n)"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:if test="not(position() eq 1)">, </xsl:if>
+        <xsl:value-of select="$tagged-name"/>
+        <xsl:apply-templates select="." mode="cardinality"/>
+        <xsl:if test="empty(self::flag)">
+            <xsl:text> ({ local-name() })</xsl:text>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template mode="cardinality" match="*[@min-occurs='0' or empty(@min-occurs)][@max-occurs='unbounded']">\*</xsl:template>
+    <xsl:template mode="cardinality" match="*[@min-occurs='1'][@max-occurs='unbounded']">*</xsl:template>
+    <xsl:template mode="cardinality" match="*[@min-occurs='0' or empty(@min-occurs)][empty(@max-occurs) or @max-occurs='1']">?</xsl:template>
+    <xsl:template mode="cardinality" match="*[@min-occurs='1'][empty(@max-occurs) or @max-occurs='1']"/>
+    <xsl:template mode="cardinality" match="*">[{@min-occurs}-{@max-occurs}]</xsl:template>
+    
+    <xsl:function name="m:signature" as="xs:string">
+        <xsl:param name="whose" as="element()"/>
+        <xsl:value-of>
+            <xsl:sequence select="substring-after(name($whose), 'define-')"/>
+            <xsl:text>:</xsl:text>
+            <xsl:sequence select="$whose/@name"/>
+            <xsl:text>|</xsl:text>
+            <xsl:sequence select="string-join(( $whose/(flag/@ref | define-flag/@name) ),':')"/>
+            <xsl:text>|</xsl:text>
+            <xsl:sequence
+                select="string-join(( $whose/(model//assembly/@ref | model/field/@ref | model/define-assembly/@name | model/define-field/@name) ),':')"/>
+            <xsl:sequence select="$whose/@as-type/string()"/>
+        </xsl:value-of>
+    </xsl:function>
+    
+</xsl:stylesheet>

--- a/toolchains/xslt-proto-v04/compare/dataset-analyze.xpl
+++ b/toolchains/xslt-proto-v04/compare/dataset-analyze.xpl
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+  xmlns:c="http://www.w3.org/ns/xproc-step" version="1.0"
+  xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+  type="m:dataset-analyze" name="dataset-analyze">
+  
+  
+  <p:input port="input" primary="true">
+    <p:empty/>
+  </p:input>
+  
+  <!--<p:option name="document-collection" select="'file:/C:/Users/wap1/Documents/usnistgov/OSCAL/content/nist.gov/SP800-53/rev4/xml/NIST_SP-800-53_rev4_catalog.xml'"/>
+  -->
+  <p:option name="document-collection" select="'https://raw.githubusercontent.com/HistoryAtState/frus/master/volumes/frus1865p3.xml'"/>
+  
+  
+  <p:input port="parameters" kind="parameter"/>
+  
+  <p:output port="a.abstract-tree" primary="false">
+    <p:pipe port="result" step="abstract-tree"/>
+  </p:output>
+  <p:serialization port="a.abstract-tree" indent="true"/>
+  
+  <p:output port="c.analysis" primary="true">
+    <p:pipe port="result" step="analyze"/>
+  </p:output>
+  <p:serialization port="c.analysis"     indent="true"/>
+  
+  <!--<p:output port="markdown" primary="false">
+    <p:pipe port="result" step="Markdown"/>
+  </p:output>-->
+  
+  <!--<p:serialization port="final"        indent="true"  method="xml"
+    doctype-public="-//W3C//DTD XHTML 1.1//EN"
+    doctype-system="http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"
+   />-->
+  <!--<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" 
+   "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">-->
+  
+  
+  <p:xslt name="abstract-tree">
+    <p:input port="stylesheet">
+      <p:document href="abstract-dataset.xsl"/>
+    </p:input>
+    <p:with-param name="collection" select="$document-collection"/>
+  </p:xslt>
+  
+  <p:xslt name="analyze" version="3.0">
+    <p:input port="stylesheet">
+      <p:document href="analyze-abstract-tree.xsl"/>
+    </p:input>
+  </p:xslt>
+ 
+</p:declare-step>

--- a/toolchains/xslt-proto-v04/compare/m2-m3-catalog-comparison.html
+++ b/toolchains/xslt-proto-v04/compare/m2-m3-catalog-comparison.html
@@ -1,0 +1,846 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <style type="text/css">
+
+body &gt; * { margin-top: 1ex }
+details { padding: 0.5ex; border: thin solid black; margin-top: 0.5ex }
+
+.brief { font-size: smaller; border: thin solid black; padding: 1ex }
+
+.changed { background-color: pink }
+.new     { background-color: lemonchiffon }
+
+.same h4 { display: none }
+
+
+.label { font-family: sans-serif; font-weight: bold; font-size: 80% }
+
+            </style>
+   <body>
+      <div class="summary">
+         <p class="brief">Comparing oscal-catalog:1.0.0-milestone3 ('Milestone 3 [M3]') with oscal-catalog:1.0.0-milestone2 ('Milestone 2 [M2]') </p>
+         <div>
+            <h5>Found in Milestone 2 [M2] not Milestone 3 [M3]: party-id, person, org, person-id, org-id, person-name, org-name, target </h5>
+         </div>
+         <div>
+            <h5>Found in Milestone 3 [M3] not Milestone 2 [M2]: revision, location, location-uuid, party-uuid, external-id, member-of-organization, party-name, text, biblio, uuid </h5>
+         </div>
+         <div>
+            <h5>Assemblies in Milestone 2 [M2]: param guideline select part metadata back-matter annotation party person org rlink address resource role responsible-party citation catalog group control </h5>
+         </div>
+         <div>
+            <h5>Assemblies in Milestone 3 [M3]: param guideline select part metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party catalog group control </h5>
+         </div>
+         <div>
+            <h5>Assemblies in either/both: param guideline select part metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party catalog group control person org </h5>
+         </div>
+         <p class="schema-name">OSCAL Control Catalog Format</p>
+         <p class="short-name">oscal-catalog</p>
+         <details id="assembly_param" class="matched-1 same">
+            <summary>
+               <code>param</code>: Parameter  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span>id?, class?, depends-on?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>id?, class?, depends-on?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>label? (field), usage\* (field), constraint\* (field), guideline\* (assembly)
+        (<i>A choice:</i>value? (field), select? (assembly)
+            )
+    , link\* (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>label? (field), usage\* (field), constraint\* (field), guideline\* (assembly)
+        (<i>A choice:</i>value? (field), select? (assembly)
+            )
+    , link\* (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_label" class="matched-1 same">
+            <summary>
+               <code>label</code>: Parameter label  with value type markup-line </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_usage" class="matched-1 same">
+            <summary>
+               <code>usage</code>: Parameter description  with value type markup-line </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>id?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>id?</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_constraint" class="matched-1 same">
+            <summary>
+               <code>constraint</code>: Constraint  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>test?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>test?</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_guideline" class="matched-1 same">
+            <summary>
+               <code>guideline</code>: Guideline  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>prose? (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>prose? (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_value" class="matched-1 same">
+            <summary>
+               <code>value</code>: Value constraint  with value type markup-line </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_select" class="matched-1 same">
+            <summary>
+               <code>select</code>: Selection  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>how-many?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>how-many?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>choice\* (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>choice\* (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_choice" class="matched-1 same">
+            <summary>
+               <code>choice</code>: Choice  with value type markup-line </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_part" class="matched-1 same">
+            <summary>
+               <code>part</code>: Part  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span>id?, name?, ns?, class?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>id?, name?, ns?, class?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>title? (field), prop\* (field), prose? (field), part\* (assembly), link\* (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>title? (field), prop\* (field), prose? (field), part\* (assembly), link\* (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="flag_test" class="matched-1 same">
+            <summary>
+               <code>test</code>: Constraint test  as type string </summary>
+         </details>
+         <details id="flag_how-many" class="matched-1 same">
+            <summary>
+               <code>how-many</code>: Cardinality  as type string </summary>
+         </details>
+         <details id="flag_depends-on" class="matched-1 same">
+            <summary>
+               <code>depends-on</code>: Depends on  as type NCName </summary>
+         </details>
+         <details id="assembly_prose" class="matched-1 same">
+            <summary>
+               <code>prose</code>: Prose  with value type markup-multiline </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_metadata" class="matched-1 changed">
+            <summary>
+               <code>metadata</code>: Publication metadata  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), **revision**\* (assembly), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), **location**\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_back-matter" class="matched-1 changed">
+            <summary>
+               <code>back-matter</code>: Back matter  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>, *citation*\* (assembly), resource\* (assembly)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>, resource\* (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_revision" class="matched-0 new">
+            <summary>
+               <code>revision</code>: Revision History Entry  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), **published**? (field), **last-modified**? (field), **version**? (field), **oscal-version**? (field), **prop**\* (field), **link**\* (field), **remarks**? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_link" class="matched-1 same">
+            <summary>
+               <code>link</code>: Link  with value type markup-line </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span>href?, rel?, media-type?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>href?, rel?, media-type?</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_published" class="matched-1 same">
+            <summary>
+               <code>published</code>: Publication Timestamp  with value type dateTime-with-timezone </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_last-modified" class="matched-1 same">
+            <summary>
+               <code>last-modified</code>: Last modified timestamp  with value type dateTime-with-timezone </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_version" class="matched-1 same">
+            <summary>
+               <code>version</code>: Document version  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_oscal-version" class="matched-1 same">
+            <summary>
+               <code>oscal-version</code>: OSCAL version  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_doc-id" class="matched-1 same">
+            <summary>
+               <code>doc-id</code>: Document Identifier  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>type?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>type?</p>
+               </div>
+            </div>
+         </details>
+         <details id="flag_type" class="matched-1 same">
+            <summary>
+               <code>type</code>: Type  as type string </summary>
+         </details>
+         <details id="assembly_prop" class="matched-1 same">
+            <summary>
+               <code>prop</code>: Property  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span>name?, id?, ns?, class?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>name?, id?, ns?, class?</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_annotation" class="matched-1 same">
+            <summary>
+               <code>annotation</code>: Annotation  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span>name?, id?, ns?, value?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>name?, id?, ns?, value?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="flag_name" class="matched-1 same">
+            <summary>
+               <code>name</code>: Name  as type NCName </summary>
+         </details>
+         <details id="flag_ns" class="matched-1 same">
+            <summary>
+               <code>ns</code>: Namespace  as type string </summary>
+         </details>
+         <details id="flag_class" class="matched-1 same">
+            <summary>
+               <code>class</code>: Class  as type NCName </summary>
+         </details>
+         <details id="assembly_location" class="matched-0 new">
+            <summary>
+               <code>location</code>: Location  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
+               </div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), **address** (assembly), **email**\* (field), **phone**\* (field), **url**\* (field), **prop**\* (field), **annotation**\* (assembly), **link**\* (field), **remarks**? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_location-uuid" class="matched-0 new">
+            <summary>
+               <code>location-uuid</code>: Location Reference  with value type uuid </summary>
+            <div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_party" class="matched-1 changed">
+            <summary>
+               <code>party</code>: Party (organization or person)  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>**uuid**?, **type**?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>*person*\* (assembly), *org*? (assembly), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>**party-name** (field), **short-name**? (field), **external-id**\* (field), prop\* (field), annotation\* (assembly), link\* (field), **address**\* (assembly), **email**\* (field), **phone**\* (field), **member-of-organization**\* (field), **location-uuid**\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_party-uuid" class="matched-0 new">
+            <summary>
+               <code>party-uuid</code>: Party Reference  with value type uuid </summary>
+            <div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_external-id" class="matched-0 new">
+            <summary>
+               <code>external-id</code>: Personal Identifier  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>**type**?</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_member-of-organization" class="matched-0 new">
+            <summary>
+               <code>member-of-organization</code>: Organizational Affiliation  with value type uuid </summary>
+            <div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_rlink" class="matched-1 same">
+            <summary>
+               <code>rlink</code>: Resource link  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span>href?, media-type?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>href?, media-type?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>hash\* (field)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>hash\* (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="flag_rel" class="matched-1 same">
+            <summary>
+               <code>rel</code>: Relation  as type NCName </summary>
+         </details>
+         <details id="flag_media-type" class="matched-1 same">
+            <summary>
+               <code>media-type</code>: Media type  as type string </summary>
+         </details>
+         <details id="assembly_party-name" class="matched-0 new">
+            <summary>
+               <code>party-name</code>: Party Name  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_short-name" class="matched-1 same">
+            <summary>
+               <code>short-name</code>: short-name  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_address" class="matched-1 same">
+            <summary>
+               <code>address</code>: Address  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>type?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>type?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_addr-line" class="matched-1 same">
+            <summary>
+               <code>addr-line</code>: Address line  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_city" class="matched-1 same">
+            <summary>
+               <code>city</code>: City  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_state" class="matched-1 same">
+            <summary>
+               <code>state</code>: State  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_postal-code" class="matched-1 same">
+            <summary>
+               <code>postal-code</code>: Postal Code  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_country" class="matched-1 same">
+            <summary>
+               <code>country</code>: Country  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_email" class="matched-1 same">
+            <summary>
+               <code>email</code>: Email  with value type email </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_phone" class="matched-1 same">
+            <summary>
+               <code>phone</code>: Telephone  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>type?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>type?</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_url" class="matched-1 same">
+            <summary>
+               <code>url</code>: URL  with value type uri </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_desc" class="matched-1 same">
+            <summary>
+               <code>desc</code>: Description  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_text" class="matched-0 new">
+            <summary>
+               <code>text</code>: Text  with value type markup-line </summary>
+            <div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_biblio" class="matched-0 new">
+            <summary>
+               <code>biblio</code>: Bibliographic Definition  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_resource" class="matched-1 changed">
+            <summary>
+               <code>resource</code>: Resource  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>desc? (field), prop\* (field)
+        (<i>A choice:</i>rlink\* (assembly), base64? (field)
+            )
+    , remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), desc? (field), prop\* (field), **doc-id**\* (field), **citation**? (assembly), rlink\* (assembly), base64\* (field), remarks? (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_citation" class="matched-1 changed">
+            <summary>
+               <code>citation</code>: Citation  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>*target*\* (field), *title*? (field), *desc*? (field), *doc-id*\* (field), prop\* (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>**text** (field), prop\* (field), **biblio**? (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_hash" class="matched-1 same">
+            <summary>
+               <code>hash</code>: Hash  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>algorithm?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>algorithm?</p>
+               </div>
+            </div>
+         </details>
+         <details id="flag_algorithm" class="matched-1 same">
+            <summary>
+               <code>algorithm</code>: Hash algorithm  as type string </summary>
+         </details>
+         <details id="assembly_role" class="matched-1 same">
+            <summary>
+               <code>role</code>: Role  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>id?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>id?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_responsible-party" class="matched-1 changed">
+            <summary>
+               <code>responsible-party</code>: Responsible Party  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>role-id?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>role-id?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>*party-id** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>**party-uuid*** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="flag_href" class="matched-1 same">
+            <summary>
+               <code>href</code>: hypertext reference  as type uri-reference </summary>
+         </details>
+         <details id="flag_id" class="matched-1 changed">
+            <summary>
+               <code>id</code>: Identifier  as type NCName </summary>
+         </details>
+         <details id="flag_uuid" class="matched-0 new">
+            <summary>
+               <code>uuid</code>: Universally Unique Identifier  as type uuid </summary>
+         </details>
+         <details id="assembly_title" class="matched-1 same">
+            <summary>
+               <code>title</code>: Title  with value type markup-line </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_base64" class="matched-1 same">
+            <summary>
+               <code>base64</code>: Base64  with value type base64Binary </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span>filename?, media-type?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>filename?, media-type?</p>
+               </div>
+            </div>
+         </details>
+         <details id="flag_filename" class="matched-1 same">
+            <summary>
+               <code>filename</code>: File Name  as type uri-reference </summary>
+         </details>
+         <details id="assembly_remarks" class="matched-1 same">
+            <summary>
+               <code>remarks</code>: Remarks  with value type markup-multiline </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_catalog" class="matched-1 changed">
+            <summary>
+               <code>catalog</code>: Catalog  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>metadata (assembly)
+        (<i>A choice:</i>group\* (assembly), control\* (assembly)
+            )
+    , back-matter? (assembly)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>metadata (assembly), **param**\* (assembly), control\* (assembly), group\* (assembly), back-matter? (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_group" class="matched-1 same">
+            <summary>
+               <code>group</code>: Control Group  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span>id?, class?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>id?, class?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>title (field), param\* (assembly), prop\* (field), part\* (assembly)
+        (<i>A choice:</i>group\* (assembly), control\* (assembly)
+            )
+    , ? (any)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>title (field), param\* (assembly), prop\* (field), part\* (assembly)
+        (<i>A choice:</i>group\* (assembly), control\* (assembly)
+            )
+    , ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_control" class="matched-1 changed">
+            <summary>
+               <code>control</code>: Control  </summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] flags: </span>id?, class?</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] flags: </span>id?, class?</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">Milestone 2 [M2] model: </span>title (field), param\* (assembly), prop\* (field), link\* (field), part\* (assembly), control\* (assembly), ? (any)</p>
+                  <p class="now">
+                     <span class="label">Milestone 3 [M3] model: </span>title (field), param\* (assembly), prop\* (field), **annotation**\* (assembly), link\* (field), part\* (assembly), control\* (assembly), ? (any)</p>
+               </div>
+            </div>
+         </details>
+      </div>
+   </body>
+</html>

--- a/toolchains/xslt-proto-v04/compare/m2-m3-profile-comparison.html
+++ b/toolchains/xslt-proto-v04/compare/m2-m3-profile-comparison.html
@@ -1,31 +1,34 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
    <style type="text/css">
 
+body &gt; * { margin-top: 1ex }
+details { padding: 0.5ex; border: thin solid black; margin-top: 0.5ex }
+
 .brief { font-size: smaller; border: thin solid black; padding: 1ex }
 
-.same    { background-color: grey }
 .changed { background-color: pink }
 .new     { background-color: lemonchiffon }
 
 .same h4 { display: none }
+
 
 .label { font-family: sans-serif; font-weight: bold; font-size: 80% }
 
             </style>
    <body>
       <div class="summary">
-         <p class="brief">Comparing oscal-profile:1.0.0-milestone3 ('\[M3]') with oscal-profile:1.0.0-milestone2 ('\[M2]') </p>
+         <p class="brief">Comparing oscal-profile:1.0.0-milestone3 ('Milestone 3 [M3]') with oscal-profile:1.0.0-milestone2 ('Milestone 2 [M2]') </p>
          <div>
-            <h5>Found in \[M2] not \[M3]: party-id, person, org, person-id, org-id, person-name, org-name, target, set, position </h5>
+            <h5>Found in Milestone 2 [M2] not Milestone 3 [M3]: party-id, person, org, person-id, org-id, person-name, org-name, target, set, position </h5>
          </div>
          <div>
-            <h5>Found in \[M3] not \[M2]: revision, location, location-uuid, party-uuid, external-id, member-of-organization, party-name, text, biblio, uuid, set-parameter </h5>
+            <h5>Found in Milestone 3 [M3] not Milestone 2 [M2]: revision, location, location-uuid, party-uuid, external-id, member-of-organization, party-name, text, biblio, uuid, set-parameter </h5>
          </div>
          <div>
-            <h5>Assemblies in \[M2]: metadata back-matter annotation party person org rlink address resource role responsible-party citation param guideline select part profile import merge custom group modify include exclude set alter add </h5>
+            <h5>Assemblies in Milestone 2 [M2]: metadata back-matter annotation party person org rlink address resource role responsible-party citation param guideline select part profile import merge custom group modify include exclude set alter add </h5>
          </div>
          <div>
-            <h5>Assemblies in \[M3]: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party param guideline select part profile import merge custom group modify include exclude set-parameter alter add </h5>
+            <h5>Assemblies in Milestone 3 [M3]: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party param guideline select part profile import merge custom group modify include exclude set-parameter alter add </h5>
          </div>
          <div>
             <h5>Assemblies in either/both: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party param guideline select part profile import merge custom group modify include exclude set-parameter alter add person org set </h5>
@@ -34,718 +37,603 @@
          <p class="short-name">oscal-profile</p>
          <details id="assembly_metadata" class="matched-1 changed">
             <summary>
-               <code>metadata</code>: Publication metadata</summary>
+               <code>metadata</code>: Publication metadata  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), **revision**\* (assembly), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), **location**\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), **revision**\* (assembly), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), **location**\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_back-matter" class="matched-1 changed">
             <summary>
-               <code>back-matter</code>: Back matter</summary>
+               <code>back-matter</code>: Back matter  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>, *citation*\* (assembly), resource\* (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>, *citation*\* (assembly), resource\* (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>, resource\* (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>, resource\* (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_revision" class="matched-0 new">
             <summary>
-               <code>revision</code>: Revision History Entry</summary>
+               <code>revision</code>: Revision History Entry  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] model: </span>
-                  </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title**? (field), **published**? (field), **last-modified**? (field), **version**? (field), **oscal-version**? (field), **prop**\* (field), **link**\* (field), **remarks**? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), **published**? (field), **last-modified**? (field), **version**? (field), **oscal-version**? (field), **prop**\* (field), **link**\* (field), **remarks**? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_link" class="matched-1 same">
             <summary>
-               <code>link</code>: Link</summary>
+               <code>link</code>: Link  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>href? (flag), rel? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>href?, rel?, media-type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>href? (flag), rel? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>href?, rel?, media-type?</p>
                </div>
             </div>
          </details>
          <details id="assembly_published" class="matched-1 same">
             <summary>
-               <code>published</code>: Publication Timestamp</summary>
+               <code>published</code>: Publication Timestamp  with value type dateTime-with-timezone </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_last-modified" class="matched-1 same">
             <summary>
-               <code>last-modified</code>: Last modified timestamp</summary>
+               <code>last-modified</code>: Last modified timestamp  with value type dateTime-with-timezone </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_version" class="matched-1 same">
             <summary>
-               <code>version</code>: Document version</summary>
+               <code>version</code>: Document version  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_oscal-version" class="matched-1 same">
             <summary>
-               <code>oscal-version</code>: OSCAL version</summary>
+               <code>oscal-version</code>: OSCAL version  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_doc-id" class="matched-1 same">
             <summary>
-               <code>doc-id</code>: Document Identifier</summary>
+               <code>doc-id</code>: Document Identifier  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>type?</p>
                </div>
             </div>
          </details>
-         <details id="assembly_type" class="matched-1 same">
+         <details id="flag_type" class="matched-1 same">
             <summary>
-               <code>type</code>: Type</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>type</code>: Type  as type string </summary>
          </details>
          <details id="assembly_prop" class="matched-1 same">
             <summary>
-               <code>prop</code>: Property</summary>
+               <code>prop</code>: Property  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>name? (flag), id? (flag), ns? (flag), class? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>name?, id?, ns?, class?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>name? (flag), id? (flag), ns? (flag), class? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>name?, id?, ns?, class?</p>
                </div>
             </div>
          </details>
          <details id="assembly_annotation" class="matched-1 same">
             <summary>
-               <code>annotation</code>: Annotation</summary>
+               <code>annotation</code>: Annotation  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>name? (flag), id? (flag), ns? (flag), value? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>name?, id?, ns?, value?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>name? (flag), id? (flag), ns? (flag), value? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>name?, id?, ns?, value?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>remarks? (field)</p>
                </div>
             </div>
          </details>
-         <details id="assembly_name" class="matched-1 same">
+         <details id="flag_name" class="matched-1 same">
             <summary>
-               <code>name</code>: Name</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>name</code>: Name  as type NCName </summary>
          </details>
-         <details id="assembly_ns" class="matched-1 same">
+         <details id="flag_ns" class="matched-1 same">
             <summary>
-               <code>ns</code>: Namespace</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>ns</code>: Namespace  as type string </summary>
          </details>
-         <details id="assembly_class" class="matched-1 same">
+         <details id="flag_class" class="matched-1 same">
             <summary>
-               <code>class</code>: Class</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>class</code>: Class  as type NCName </summary>
          </details>
          <details id="assembly_location" class="matched-0 new">
             <summary>
-               <code>location</code>: Location</summary>
+               <code>location</code>: Location  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
                </div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] model: </span>
-                  </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title**? (field), **address** (assembly), **email**\* (field), **phone**\* (field), **url**\* (field), **prop**\* (field), **annotation**\* (assembly), **link**\* (field), **remarks**? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), **address** (assembly), **email**\* (field), **phone**\* (field), **url**\* (field), **prop**\* (field), **annotation**\* (assembly), **link**\* (field), **remarks**? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_location-uuid" class="matched-0 new">
             <summary>
-               <code>location-uuid</code>: Location Reference</summary>
+               <code>location-uuid</code>: Location Reference  with value type uuid </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_party" class="matched-1 changed">
             <summary>
-               <code>party</code>: Party (organization or person)</summary>
+               <code>party</code>: Party (organization or person)  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>**uuid**? (flag), **type**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>**uuid**?, **type**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>*person*\* (assembly), *org*? (assembly), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>*person*\* (assembly), *org*? (assembly), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**party-name** (field), **short-name**? (field), **external-id**\* (field), prop\* (field), annotation\* (assembly), link\* (field), **address**\* (assembly), **email**\* (field), **phone**\* (field), **member-of-organization**\* (field), **location-uuid**\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**party-name** (field), **short-name**? (field), **external-id**\* (field), prop\* (field), annotation\* (assembly), link\* (field), **address**\* (assembly), **email**\* (field), **phone**\* (field), **member-of-organization**\* (field), **location-uuid**\* (field), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_party-uuid" class="matched-0 new">
             <summary>
-               <code>party-uuid</code>: Party Reference</summary>
+               <code>party-uuid</code>: Party Reference  with value type uuid </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_external-id" class="matched-0 new">
             <summary>
-               <code>external-id</code>: Personal Identifier</summary>
+               <code>external-id</code>: Personal Identifier  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**type**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**type**?</p>
                </div>
             </div>
          </details>
          <details id="assembly_member-of-organization" class="matched-0 new">
             <summary>
-               <code>member-of-organization</code>: Organizational Affiliation</summary>
+               <code>member-of-organization</code>: Organizational Affiliation  with value type uuid </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_rlink" class="matched-1 same">
             <summary>
-               <code>rlink</code>: Resource link</summary>
+               <code>rlink</code>: Resource link  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>href? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>href?, media-type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>href? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>href?, media-type?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>hash\* (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>hash\* (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>hash\* (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>hash\* (field)</p>
                </div>
             </div>
          </details>
-         <details id="assembly_rel" class="matched-1 same">
+         <details id="flag_rel" class="matched-1 same">
             <summary>
-               <code>rel</code>: Relation</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>rel</code>: Relation  as type NCName </summary>
          </details>
-         <details id="assembly_media-type" class="matched-1 same">
+         <details id="flag_media-type" class="matched-1 same">
             <summary>
-               <code>media-type</code>: Media type</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>media-type</code>: Media type  as type string </summary>
          </details>
          <details id="assembly_party-name" class="matched-0 new">
             <summary>
-               <code>party-name</code>: Party Name</summary>
+               <code>party-name</code>: Party Name  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_short-name" class="matched-1 same">
             <summary>
-               <code>short-name</code>: short-name</summary>
+               <code>short-name</code>: short-name  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_address" class="matched-1 same">
             <summary>
-               <code>address</code>: Address</summary>
+               <code>address</code>: Address  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>type?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_addr-line" class="matched-1 same">
             <summary>
-               <code>addr-line</code>: Address line</summary>
+               <code>addr-line</code>: Address line  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_city" class="matched-1 same">
             <summary>
-               <code>city</code>: City</summary>
+               <code>city</code>: City  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_state" class="matched-1 same">
             <summary>
-               <code>state</code>: State</summary>
+               <code>state</code>: State  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_postal-code" class="matched-1 same">
             <summary>
-               <code>postal-code</code>: Postal Code</summary>
+               <code>postal-code</code>: Postal Code  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_country" class="matched-1 same">
             <summary>
-               <code>country</code>: Country</summary>
+               <code>country</code>: Country  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_email" class="matched-1 same">
             <summary>
-               <code>email</code>: Email</summary>
+               <code>email</code>: Email  with value type email </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_phone" class="matched-1 same">
             <summary>
-               <code>phone</code>: Telephone</summary>
+               <code>phone</code>: Telephone  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>type?</p>
                </div>
             </div>
          </details>
          <details id="assembly_url" class="matched-1 same">
             <summary>
-               <code>url</code>: URL</summary>
+               <code>url</code>: URL  with value type uri </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_desc" class="matched-1 same">
             <summary>
-               <code>desc</code>: Description</summary>
+               <code>desc</code>: Description  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_text" class="matched-0 new">
             <summary>
-               <code>text</code>: Text</summary>
+               <code>text</code>: Text  with value type markup-line </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_biblio" class="matched-0 new">
             <summary>
-               <code>biblio</code>: Bibliographic Definition</summary>
+               <code>biblio</code>: Bibliographic Definition  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] model: </span>
-                  </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>? (any)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>? (any)</p>
                </div>
             </div>
          </details>
          <details id="assembly_resource" class="matched-1 changed">
             <summary>
-               <code>resource</code>: Resource</summary>
+               <code>resource</code>: Resource  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>desc? (field), prop\* (field)
+                     <span class="label">Milestone 2 [M2] model: </span>desc? (field), prop\* (field)
         (<i>A choice:</i>rlink\* (assembly), base64? (field)
             )
     , remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title**? (field), desc? (field), prop\* (field), **doc-id**\* (field), **citation**? (assembly), rlink\* (assembly), base64\* (field), remarks? (field), ? (any)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), desc? (field), prop\* (field), **doc-id**\* (field), **citation**? (assembly), rlink\* (assembly), base64\* (field), remarks? (field), ? (any)</p>
                </div>
             </div>
          </details>
          <details id="assembly_citation" class="matched-1 changed">
             <summary>
-               <code>citation</code>: Citation</summary>
+               <code>citation</code>: Citation  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>*target*\* (field), *title*? (field), *desc*? (field), *doc-id*\* (field), prop\* (field), ? (any)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>*target*\* (field), *title*? (field), *desc*? (field), *doc-id*\* (field), prop\* (field), ? (any)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**text** (field), prop\* (field), **biblio**? (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**text** (field), prop\* (field), **biblio**? (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_hash" class="matched-1 same">
             <summary>
-               <code>hash</code>: Hash</summary>
+               <code>hash</code>: Hash  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>algorithm? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>algorithm?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>algorithm? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>algorithm?</p>
                </div>
             </div>
          </details>
-         <details id="assembly_algorithm" class="matched-1 same">
+         <details id="flag_algorithm" class="matched-1 same">
             <summary>
-               <code>algorithm</code>: Hash algorithm</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>algorithm</code>: Hash algorithm  as type string </summary>
          </details>
          <details id="assembly_role" class="matched-1 same">
             <summary>
-               <code>role</code>: Role</summary>
+               <code>role</code>: Role  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_responsible-party" class="matched-1 changed">
             <summary>
-               <code>responsible-party</code>: Responsible Party</summary>
+               <code>responsible-party</code>: Responsible Party  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>role-id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>role-id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>role-id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>role-id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>*party-id** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>*party-id** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**party-uuid*** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**party-uuid*** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                </div>
             </div>
          </details>
-         <details id="assembly_href" class="matched-1 same">
+         <details id="flag_href" class="matched-1 same">
             <summary>
-               <code>href</code>: hypertext reference</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>href</code>: hypertext reference  as type uri-reference </summary>
          </details>
-         <details id="assembly_id" class="matched-1 changed">
+         <details id="flag_id" class="matched-1 changed">
             <summary>
-               <code>id</code>: Identifier</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>id</code>: Identifier  as type NCName </summary>
          </details>
-         <details id="assembly_uuid" class="matched-0 new">
+         <details id="flag_uuid" class="matched-0 new">
             <summary>
-               <code>uuid</code>: Universally Unique Identifier</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>uuid</code>: Universally Unique Identifier  as type uuid </summary>
          </details>
          <details id="assembly_title" class="matched-1 same">
             <summary>
-               <code>title</code>: Title</summary>
+               <code>title</code>: Title  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_base64" class="matched-1 same">
             <summary>
-               <code>base64</code>: Base64</summary>
+               <code>base64</code>: Base64  with value type base64Binary </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>filename? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>filename?, media-type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>filename? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>filename?, media-type?</p>
                </div>
             </div>
          </details>
-         <details id="assembly_filename" class="matched-1 same">
+         <details id="flag_filename" class="matched-1 same">
             <summary>
-               <code>filename</code>: File Name</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>filename</code>: File Name  as type uri-reference </summary>
          </details>
          <details id="assembly_remarks" class="matched-1 same">
             <summary>
-               <code>remarks</code>: Remarks</summary>
+               <code>remarks</code>: Remarks  with value type markup-multiline </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_param" class="matched-1 same">
             <summary>
-               <code>param</code>: Parameter</summary>
+               <code>param</code>: Parameter  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>id? (flag), class? (flag), depends-on? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>id?, class?, depends-on?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>id? (flag), class? (flag), depends-on? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>id?, class?, depends-on?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>label? (field), usage\* (field), constraint\* (field), guideline\* (assembly)
+                     <span class="label">Milestone 2 [M2] model: </span>label? (field), usage\* (field), constraint\* (field), guideline\* (assembly)
         (<i>A choice:</i>value? (field), select? (assembly)
             )
     , link\* (field), ? (any)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>label? (field), usage\* (field), constraint\* (field), guideline\* (assembly)
+                     <span class="label">Milestone 3 [M3] model: </span>label? (field), usage\* (field), constraint\* (field), guideline\* (assembly)
         (<i>A choice:</i>value? (field), select? (assembly)
             )
     , link\* (field), ? (any)</p>
@@ -754,220 +642,196 @@
          </details>
          <details id="assembly_label" class="matched-1 same">
             <summary>
-               <code>label</code>: Parameter label</summary>
+               <code>label</code>: Parameter label  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_usage" class="matched-1 same">
             <summary>
-               <code>usage</code>: Parameter description</summary>
+               <code>usage</code>: Parameter description  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>id?</p>
                </div>
             </div>
          </details>
          <details id="assembly_constraint" class="matched-1 same">
             <summary>
-               <code>constraint</code>: Constraint</summary>
+               <code>constraint</code>: Constraint  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>test? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>test?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>test? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>test?</p>
                </div>
             </div>
          </details>
          <details id="assembly_guideline" class="matched-1 same">
             <summary>
-               <code>guideline</code>: Guideline</summary>
+               <code>guideline</code>: Guideline  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>prose? (field), ? (any)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>prose? (field), ? (any)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>prose? (field), ? (any)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>prose? (field), ? (any)</p>
                </div>
             </div>
          </details>
          <details id="assembly_value" class="matched-1 same">
             <summary>
-               <code>value</code>: Value constraint</summary>
+               <code>value</code>: Value constraint  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_select" class="matched-1 same">
             <summary>
-               <code>select</code>: Selection</summary>
+               <code>select</code>: Selection  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>how-many? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>how-many?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>how-many? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>how-many?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>choice\* (field), ? (any)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>choice\* (field), ? (any)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>choice\* (field), ? (any)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>choice\* (field), ? (any)</p>
                </div>
             </div>
          </details>
          <details id="assembly_choice" class="matched-1 same">
             <summary>
-               <code>choice</code>: Choice</summary>
+               <code>choice</code>: Choice  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_part" class="matched-1 same">
             <summary>
-               <code>part</code>: Part</summary>
+               <code>part</code>: Part  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>id? (flag), name? (flag), ns? (flag), class? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>id?, name?, ns?, class?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>id? (flag), name? (flag), ns? (flag), class? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>id?, name?, ns?, class?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>title? (field), prop\* (field), prose? (field), part\* (assembly), link\* (field), ? (any)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>title? (field), prop\* (field), prose? (field), part\* (assembly), link\* (field), ? (any)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>title? (field), prop\* (field), prose? (field), part\* (assembly), link\* (field), ? (any)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>title? (field), prop\* (field), prose? (field), part\* (assembly), link\* (field), ? (any)</p>
                </div>
             </div>
          </details>
-         <details id="assembly_test" class="matched-1 same">
+         <details id="flag_test" class="matched-1 same">
             <summary>
-               <code>test</code>: Constraint test</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>test</code>: Constraint test  as type string </summary>
          </details>
-         <details id="assembly_how-many" class="matched-1 same">
+         <details id="flag_how-many" class="matched-1 same">
             <summary>
-               <code>how-many</code>: Cardinality</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>how-many</code>: Cardinality  as type string </summary>
          </details>
-         <details id="assembly_depends-on" class="matched-1 same">
+         <details id="flag_depends-on" class="matched-1 same">
             <summary>
-               <code>depends-on</code>: Depends on</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>depends-on</code>: Depends on  as type NCName </summary>
          </details>
          <details id="assembly_prose" class="matched-1 same">
             <summary>
-               <code>prose</code>: Prose</summary>
+               <code>prose</code>: Prose  with value type markup-multiline </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_profile" class="matched-1 changed">
             <summary>
-               <code>profile</code>: Profile</summary>
+               <code>profile</code>: Profile  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>metadata (assembly), import\* (assembly), merge? (assembly), modify? (assembly), back-matter? (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>metadata (assembly), import\* (assembly), merge? (assembly), modify? (assembly), back-matter? (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>metadata (assembly), import* (assembly), merge? (assembly), modify? (assembly), back-matter? (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>metadata (assembly), import* (assembly), merge? (assembly), modify? (assembly), back-matter? (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_import" class="matched-1 same">
             <summary>
-               <code>import</code>: Import resource</summary>
+               <code>import</code>: Import resource  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>href? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>href?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>href? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>href?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>include? (assembly), exclude? (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>include? (assembly), exclude? (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>include? (assembly), exclude? (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>include? (assembly), exclude? (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_merge" class="matched-1 same">
             <summary>
-               <code>merge</code>: Merge controls</summary>
+               <code>merge</code>: Merge controls  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>combine? (field)
+                     <span class="label">Milestone 2 [M2] model: </span>combine? (field)
         (<i>A choice:</i>as-is? (field), custom? (assembly)
             )
     </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>combine? (field)
+                     <span class="label">Milestone 3 [M3] model: </span>combine? (field)
         (<i>A choice:</i>as-is? (field), custom? (assembly)
             )
     </p>
@@ -976,58 +840,50 @@
          </details>
          <details id="assembly_combine" class="matched-1 same">
             <summary>
-               <code>combine</code>: Combination rule</summary>
+               <code>combine</code>: Combination rule  with value type empty </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>method? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>method?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>method? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>method?</p>
                </div>
             </div>
          </details>
          <details id="assembly_as-is" class="matched-1 same">
             <summary>
-               <code>as-is</code>: As is</summary>
+               <code>as-is</code>: As is  with value type boolean </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
-         <details id="assembly_method" class="matched-1 same">
+         <details id="flag_method" class="matched-1 same">
             <summary>
-               <code>method</code>: Combination method</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>method</code>: Combination method  as type string </summary>
          </details>
          <details id="assembly_custom" class="matched-1 same">
             <summary>
-               <code>custom</code>: Custom grouping</summary>
+               <code>custom</code>: Custom grouping  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>
+                     <span class="label">Milestone 2 [M2] model: </span>
         (<i>A choice:</i>group\* (assembly), call\* (field), match\* (field)
             )
     </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>
+                     <span class="label">Milestone 3 [M3] model: </span>
         (<i>A choice:</i>group\* (assembly), call\* (field), match\* (field)
             )
     </p>
@@ -1036,22 +892,22 @@
          </details>
          <details id="assembly_group" class="matched-1 same">
             <summary>
-               <code>group</code>: Control group</summary>
+               <code>group</code>: Control group  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>id? (flag), class? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>id?, class?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>id? (flag), class? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>id?, class?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>title? (field), param\* (assembly), prop\* (field), part\* (assembly)
+                     <span class="label">Milestone 2 [M2] model: </span>title? (field), param\* (assembly), prop\* (field), part\* (assembly)
         (<i>A choice:</i>group\* (assembly), call\* (field), match\* (field)
             )
     </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>title? (field), param\* (assembly), prop\* (field), part\* (assembly)
+                     <span class="label">Milestone 3 [M3] model: </span>title? (field), param\* (assembly), prop\* (field), part\* (assembly)
         (<i>A choice:</i>group\* (assembly), call\* (field), match\* (field)
             )
     </p>
@@ -1060,40 +916,40 @@
          </details>
          <details id="assembly_modify" class="matched-1 changed">
             <summary>
-               <code>modify</code>: Modify controls</summary>
+               <code>modify</code>: Modify controls  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>*set*\* (assembly), alter\* (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>*set*\* (assembly), alter\* (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**set-parameter**\* (assembly), alter\* (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**set-parameter**\* (assembly), alter\* (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_include" class="matched-1 same">
             <summary>
-               <code>include</code>: Include controls</summary>
+               <code>include</code>: Include controls  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>
+                     <span class="label">Milestone 2 [M2] model: </span>
         (<i>A choice:</i>all? (field), call\* (field), match\* (field)
             )
     </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>
+                     <span class="label">Milestone 3 [M3] model: </span>
         (<i>A choice:</i>all? (field), call\* (field), match\* (field)
             )
     </p>
@@ -1102,58 +958,58 @@
          </details>
          <details id="assembly_all" class="matched-1 same">
             <summary>
-               <code>all</code>: Include all</summary>
+               <code>all</code>: Include all  with value type empty </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>with-child-controls? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>with-child-controls?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>with-child-controls? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>with-child-controls?</p>
                </div>
             </div>
          </details>
          <details id="assembly_call" class="matched-1 same">
             <summary>
-               <code>call</code>: Call</summary>
+               <code>call</code>: Call  with value type empty </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>control-id? (flag), with-child-controls? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>control-id?, with-child-controls?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>control-id? (flag), with-child-controls? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>control-id?, with-child-controls?</p>
                </div>
             </div>
          </details>
          <details id="assembly_match" class="matched-1 same">
             <summary>
-               <code>match</code>: Match controls by identifier</summary>
+               <code>match</code>: Match controls by identifier  with value type empty </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>pattern? (flag), order? (flag), with-child-controls? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>pattern?, order?, with-child-controls?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>pattern? (flag), order? (flag), with-child-controls? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>pattern?, order?, with-child-controls?</p>
                </div>
             </div>
          </details>
          <details id="assembly_exclude" class="matched-1 same">
             <summary>
-               <code>exclude</code>: Exclude controls</summary>
+               <code>exclude</code>: Exclude controls  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>
+                     <span class="label">Milestone 2 [M2] model: </span>
         (<i>A choice:</i>call\* (field), match\* (field)
             )
     </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>
+                     <span class="label">Milestone 3 [M3] model: </span>
         (<i>A choice:</i>call\* (field), match\* (field)
             )
     </p>
@@ -1162,20 +1018,15 @@
          </details>
          <details id="assembly_set-parameter" class="matched-0 new">
             <summary>
-               <code>set-parameter</code>: Parameter Setting</summary>
+               <code>set-parameter</code>: Parameter Setting  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>**param-id**? (flag), **class**? (flag), **depends-on**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>**param-id**?, **class**?, **depends-on**?</p>
                </div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] model: </span>
-                  </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>, **label**? (field), **usage**\* (field), **constraint**\* (field), **guideline**\* (assembly)
+                     <span class="label">Milestone 3 [M3] model: </span>, **label**? (field), **usage**\* (field), **constraint**\* (field), **guideline**\* (assembly)
         (<i>A choice:</i>**value**? (field), **select**? (assembly)
             )
     , **link**\* (field)</p>
@@ -1184,99 +1035,67 @@
          </details>
          <details id="assembly_alter" class="matched-1 same">
             <summary>
-               <code>alter</code>: Alteration</summary>
+               <code>alter</code>: Alteration  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>control-id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>control-id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>control-id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>control-id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>remove\* (field), add\* (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>remove\* (field), add\* (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>remove\* (field), add\* (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>remove\* (field), add\* (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_remove" class="matched-1 same">
             <summary>
-               <code>remove</code>: Removal</summary>
+               <code>remove</code>: Removal  with value type empty </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>name-ref? (flag), class-ref? (flag), id-ref? (flag), item-name? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>name-ref?, class-ref?, id-ref?, item-name?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>name-ref? (flag), class-ref? (flag), id-ref? (flag), item-name? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>name-ref?, class-ref?, id-ref?, item-name?</p>
                </div>
             </div>
          </details>
          <details id="assembly_add" class="matched-1 changed">
             <summary>
-               <code>add</code>: Addition</summary>
+               <code>add</code>: Addition  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>position? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>position?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>position? (flag), **id-ref**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>position?, **id-ref**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>title? (field), param\* (assembly), prop\* (field), link\* (field), part\* (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>title? (field), param\* (assembly), prop\* (field), link\* (field), part\* (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>title? (field), param\* (assembly), prop\* (field), **annotation**\* (assembly), link\* (field), part\* (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>title? (field), param\* (assembly), prop\* (field), **annotation**\* (assembly), link\* (field), part\* (assembly)</p>
                </div>
             </div>
          </details>
-         <details id="assembly_control-id" class="matched-1 same">
+         <details id="flag_control-id" class="matched-1 same">
             <summary>
-               <code>control-id</code>: Control ID</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>control-id</code>: Control ID  as type NCName </summary>
          </details>
-         <details id="assembly_with-child-controls" class="matched-1 same">
+         <details id="flag_with-child-controls" class="matched-1 same">
             <summary>
-               <code>with-child-controls</code>: Include contained controls with control</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>with-child-controls</code>: Include contained controls with control  as type NCName </summary>
          </details>
-         <details id="assembly_pattern" class="matched-1 same">
+         <details id="flag_pattern" class="matched-1 same">
             <summary>
-               <code>pattern</code>: Pattern</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>pattern</code>: Pattern  as type string </summary>
          </details>
-         <details id="assembly_order" class="matched-1 same">
+         <details id="flag_order" class="matched-1 same">
             <summary>
-               <code>order</code>: Order</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>order</code>: Order  as type NCName </summary>
          </details>
       </div>
    </body>

--- a/toolchains/xslt-proto-v04/compare/m2-m3-profile-comparison.html
+++ b/toolchains/xslt-proto-v04/compare/m2-m3-profile-comparison.html
@@ -1,0 +1,1283 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <style type="text/css">
+
+.brief { font-size: smaller; border: thin solid black; padding: 1ex }
+
+.same    { background-color: grey }
+.changed { background-color: pink }
+.new     { background-color: lemonchiffon }
+
+.same h4 { display: none }
+
+.label { font-family: sans-serif; font-weight: bold; font-size: 80% }
+
+            </style>
+   <body>
+      <div class="summary">
+         <p class="brief">Comparing oscal-profile:1.0.0-milestone3 ('\[M3]') with oscal-profile:1.0.0-milestone2 ('\[M2]') </p>
+         <div>
+            <h5>Found in \[M2] not \[M3]: party-id, person, org, person-id, org-id, person-name, org-name, target, set, position </h5>
+         </div>
+         <div>
+            <h5>Found in \[M3] not \[M2]: revision, location, location-uuid, party-uuid, external-id, member-of-organization, party-name, text, biblio, uuid, set-parameter </h5>
+         </div>
+         <div>
+            <h5>Assemblies in \[M2]: metadata back-matter annotation party person org rlink address resource role responsible-party citation param guideline select part profile import merge custom group modify include exclude set alter add </h5>
+         </div>
+         <div>
+            <h5>Assemblies in \[M3]: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party param guideline select part profile import merge custom group modify include exclude set-parameter alter add </h5>
+         </div>
+         <div>
+            <h5>Assemblies in either/both: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party param guideline select part profile import merge custom group modify include exclude set-parameter alter add person org set </h5>
+         </div>
+         <p class="schema-name">OSCAL Profile Metaschema</p>
+         <p class="short-name">oscal-profile</p>
+         <details id="assembly_metadata" class="matched-1 changed">
+            <summary>
+               <code>metadata</code>: Publication metadata</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), **revision**\* (assembly), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), **location**\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_back-matter" class="matched-1 changed">
+            <summary>
+               <code>back-matter</code>: Back matter</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>, *citation*\* (assembly), resource\* (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>, resource\* (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_revision" class="matched-0 new">
+            <summary>
+               <code>revision</code>: Revision History Entry</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+                  </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title**? (field), **published**? (field), **last-modified**? (field), **version**? (field), **oscal-version**? (field), **prop**\* (field), **link**\* (field), **remarks**? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_link" class="matched-1 same">
+            <summary>
+               <code>link</code>: Link</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>href? (flag), rel? (flag), media-type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>href? (flag), rel? (flag), media-type? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_published" class="matched-1 same">
+            <summary>
+               <code>published</code>: Publication Timestamp</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_last-modified" class="matched-1 same">
+            <summary>
+               <code>last-modified</code>: Last modified timestamp</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_version" class="matched-1 same">
+            <summary>
+               <code>version</code>: Document version</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_oscal-version" class="matched-1 same">
+            <summary>
+               <code>oscal-version</code>: OSCAL version</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_doc-id" class="matched-1 same">
+            <summary>
+               <code>doc-id</code>: Document Identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_type" class="matched-1 same">
+            <summary>
+               <code>type</code>: Type</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_prop" class="matched-1 same">
+            <summary>
+               <code>prop</code>: Property</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>name? (flag), id? (flag), ns? (flag), class? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>name? (flag), id? (flag), ns? (flag), class? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_annotation" class="matched-1 same">
+            <summary>
+               <code>annotation</code>: Annotation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>name? (flag), id? (flag), ns? (flag), value? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>name? (flag), id? (flag), ns? (flag), value? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_name" class="matched-1 same">
+            <summary>
+               <code>name</code>: Name</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_ns" class="matched-1 same">
+            <summary>
+               <code>ns</code>: Namespace</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_class" class="matched-1 same">
+            <summary>
+               <code>class</code>: Class</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_location" class="matched-0 new">
+            <summary>
+               <code>location</code>: Location</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+                  </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title**? (field), **address** (assembly), **email**\* (field), **phone**\* (field), **url**\* (field), **prop**\* (field), **annotation**\* (assembly), **link**\* (field), **remarks**? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_location-uuid" class="matched-0 new">
+            <summary>
+               <code>location-uuid</code>: Location Reference</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_party" class="matched-1 changed">
+            <summary>
+               <code>party</code>: Party (organization or person)</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>**uuid**? (flag), **type**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>*person*\* (assembly), *org*? (assembly), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**party-name** (field), **short-name**? (field), **external-id**\* (field), prop\* (field), annotation\* (assembly), link\* (field), **address**\* (assembly), **email**\* (field), **phone**\* (field), **member-of-organization**\* (field), **location-uuid**\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_party-uuid" class="matched-0 new">
+            <summary>
+               <code>party-uuid</code>: Party Reference</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_external-id" class="matched-0 new">
+            <summary>
+               <code>external-id</code>: Personal Identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**type**? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_member-of-organization" class="matched-0 new">
+            <summary>
+               <code>member-of-organization</code>: Organizational Affiliation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_rlink" class="matched-1 same">
+            <summary>
+               <code>rlink</code>: Resource link</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>href? (flag), media-type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>href? (flag), media-type? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>hash\* (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>hash\* (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_rel" class="matched-1 same">
+            <summary>
+               <code>rel</code>: Relation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_media-type" class="matched-1 same">
+            <summary>
+               <code>media-type</code>: Media type</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_party-name" class="matched-0 new">
+            <summary>
+               <code>party-name</code>: Party Name</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_short-name" class="matched-1 same">
+            <summary>
+               <code>short-name</code>: short-name</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_address" class="matched-1 same">
+            <summary>
+               <code>address</code>: Address</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_addr-line" class="matched-1 same">
+            <summary>
+               <code>addr-line</code>: Address line</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_city" class="matched-1 same">
+            <summary>
+               <code>city</code>: City</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_state" class="matched-1 same">
+            <summary>
+               <code>state</code>: State</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_postal-code" class="matched-1 same">
+            <summary>
+               <code>postal-code</code>: Postal Code</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_country" class="matched-1 same">
+            <summary>
+               <code>country</code>: Country</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_email" class="matched-1 same">
+            <summary>
+               <code>email</code>: Email</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_phone" class="matched-1 same">
+            <summary>
+               <code>phone</code>: Telephone</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_url" class="matched-1 same">
+            <summary>
+               <code>url</code>: URL</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_desc" class="matched-1 same">
+            <summary>
+               <code>desc</code>: Description</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_text" class="matched-0 new">
+            <summary>
+               <code>text</code>: Text</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_biblio" class="matched-0 new">
+            <summary>
+               <code>biblio</code>: Bibliographic Definition</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+                  </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_resource" class="matched-1 changed">
+            <summary>
+               <code>resource</code>: Resource</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>desc? (field), prop\* (field)
+        (<i>A choice:</i>rlink\* (assembly), base64? (field)
+            )
+    , remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title**? (field), desc? (field), prop\* (field), **doc-id**\* (field), **citation**? (assembly), rlink\* (assembly), base64\* (field), remarks? (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_citation" class="matched-1 changed">
+            <summary>
+               <code>citation</code>: Citation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>*target*\* (field), *title*? (field), *desc*? (field), *doc-id*\* (field), prop\* (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**text** (field), prop\* (field), **biblio**? (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_hash" class="matched-1 same">
+            <summary>
+               <code>hash</code>: Hash</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>algorithm? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>algorithm? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_algorithm" class="matched-1 same">
+            <summary>
+               <code>algorithm</code>: Hash algorithm</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_role" class="matched-1 same">
+            <summary>
+               <code>role</code>: Role</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_responsible-party" class="matched-1 changed">
+            <summary>
+               <code>responsible-party</code>: Responsible Party</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>role-id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>role-id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>*party-id** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**party-uuid*** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_href" class="matched-1 same">
+            <summary>
+               <code>href</code>: hypertext reference</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_id" class="matched-1 changed">
+            <summary>
+               <code>id</code>: Identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_uuid" class="matched-0 new">
+            <summary>
+               <code>uuid</code>: Universally Unique Identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_title" class="matched-1 same">
+            <summary>
+               <code>title</code>: Title</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_base64" class="matched-1 same">
+            <summary>
+               <code>base64</code>: Base64</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>filename? (flag), media-type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>filename? (flag), media-type? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_filename" class="matched-1 same">
+            <summary>
+               <code>filename</code>: File Name</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_remarks" class="matched-1 same">
+            <summary>
+               <code>remarks</code>: Remarks</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_param" class="matched-1 same">
+            <summary>
+               <code>param</code>: Parameter</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>id? (flag), class? (flag), depends-on? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>id? (flag), class? (flag), depends-on? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>label? (field), usage\* (field), constraint\* (field), guideline\* (assembly)
+        (<i>A choice:</i>value? (field), select? (assembly)
+            )
+    , link\* (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>label? (field), usage\* (field), constraint\* (field), guideline\* (assembly)
+        (<i>A choice:</i>value? (field), select? (assembly)
+            )
+    , link\* (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_label" class="matched-1 same">
+            <summary>
+               <code>label</code>: Parameter label</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_usage" class="matched-1 same">
+            <summary>
+               <code>usage</code>: Parameter description</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_constraint" class="matched-1 same">
+            <summary>
+               <code>constraint</code>: Constraint</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>test? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>test? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_guideline" class="matched-1 same">
+            <summary>
+               <code>guideline</code>: Guideline</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>prose? (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>prose? (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_value" class="matched-1 same">
+            <summary>
+               <code>value</code>: Value constraint</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_select" class="matched-1 same">
+            <summary>
+               <code>select</code>: Selection</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>how-many? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>how-many? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>choice\* (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>choice\* (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_choice" class="matched-1 same">
+            <summary>
+               <code>choice</code>: Choice</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_part" class="matched-1 same">
+            <summary>
+               <code>part</code>: Part</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>id? (flag), name? (flag), ns? (flag), class? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>id? (flag), name? (flag), ns? (flag), class? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>title? (field), prop\* (field), prose? (field), part\* (assembly), link\* (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>title? (field), prop\* (field), prose? (field), part\* (assembly), link\* (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_test" class="matched-1 same">
+            <summary>
+               <code>test</code>: Constraint test</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_how-many" class="matched-1 same">
+            <summary>
+               <code>how-many</code>: Cardinality</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_depends-on" class="matched-1 same">
+            <summary>
+               <code>depends-on</code>: Depends on</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_prose" class="matched-1 same">
+            <summary>
+               <code>prose</code>: Prose</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_profile" class="matched-1 changed">
+            <summary>
+               <code>profile</code>: Profile</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>metadata (assembly), import\* (assembly), merge? (assembly), modify? (assembly), back-matter? (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>metadata (assembly), import* (assembly), merge? (assembly), modify? (assembly), back-matter? (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_import" class="matched-1 same">
+            <summary>
+               <code>import</code>: Import resource</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>href? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>href? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>include? (assembly), exclude? (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>include? (assembly), exclude? (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_merge" class="matched-1 same">
+            <summary>
+               <code>merge</code>: Merge controls</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>combine? (field)
+        (<i>A choice:</i>as-is? (field), custom? (assembly)
+            )
+    </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>combine? (field)
+        (<i>A choice:</i>as-is? (field), custom? (assembly)
+            )
+    </p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_combine" class="matched-1 same">
+            <summary>
+               <code>combine</code>: Combination rule</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>method? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>method? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_as-is" class="matched-1 same">
+            <summary>
+               <code>as-is</code>: As is</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_method" class="matched-1 same">
+            <summary>
+               <code>method</code>: Combination method</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_custom" class="matched-1 same">
+            <summary>
+               <code>custom</code>: Custom grouping</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+        (<i>A choice:</i>group\* (assembly), call\* (field), match\* (field)
+            )
+    </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>
+        (<i>A choice:</i>group\* (assembly), call\* (field), match\* (field)
+            )
+    </p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_group" class="matched-1 same">
+            <summary>
+               <code>group</code>: Control group</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>id? (flag), class? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>id? (flag), class? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>title? (field), param\* (assembly), prop\* (field), part\* (assembly)
+        (<i>A choice:</i>group\* (assembly), call\* (field), match\* (field)
+            )
+    </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>title? (field), param\* (assembly), prop\* (field), part\* (assembly)
+        (<i>A choice:</i>group\* (assembly), call\* (field), match\* (field)
+            )
+    </p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_modify" class="matched-1 changed">
+            <summary>
+               <code>modify</code>: Modify controls</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>*set*\* (assembly), alter\* (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**set-parameter**\* (assembly), alter\* (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_include" class="matched-1 same">
+            <summary>
+               <code>include</code>: Include controls</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+        (<i>A choice:</i>all? (field), call\* (field), match\* (field)
+            )
+    </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>
+        (<i>A choice:</i>all? (field), call\* (field), match\* (field)
+            )
+    </p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_all" class="matched-1 same">
+            <summary>
+               <code>all</code>: Include all</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>with-child-controls? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>with-child-controls? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_call" class="matched-1 same">
+            <summary>
+               <code>call</code>: Call</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>control-id? (flag), with-child-controls? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>control-id? (flag), with-child-controls? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_match" class="matched-1 same">
+            <summary>
+               <code>match</code>: Match controls by identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>pattern? (flag), order? (flag), with-child-controls? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>pattern? (flag), order? (flag), with-child-controls? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_exclude" class="matched-1 same">
+            <summary>
+               <code>exclude</code>: Exclude controls</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+        (<i>A choice:</i>call\* (field), match\* (field)
+            )
+    </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>
+        (<i>A choice:</i>call\* (field), match\* (field)
+            )
+    </p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_set-parameter" class="matched-0 new">
+            <summary>
+               <code>set-parameter</code>: Parameter Setting</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>**param-id**? (flag), **class**? (flag), **depends-on**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+                  </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>, **label**? (field), **usage**\* (field), **constraint**\* (field), **guideline**\* (assembly)
+        (<i>A choice:</i>**value**? (field), **select**? (assembly)
+            )
+    , **link**\* (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_alter" class="matched-1 same">
+            <summary>
+               <code>alter</code>: Alteration</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>control-id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>control-id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>remove\* (field), add\* (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>remove\* (field), add\* (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_remove" class="matched-1 same">
+            <summary>
+               <code>remove</code>: Removal</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>name-ref? (flag), class-ref? (flag), id-ref? (flag), item-name? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>name-ref? (flag), class-ref? (flag), id-ref? (flag), item-name? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_add" class="matched-1 changed">
+            <summary>
+               <code>add</code>: Addition</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>position? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>position? (flag), **id-ref**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>title? (field), param\* (assembly), prop\* (field), link\* (field), part\* (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>title? (field), param\* (assembly), prop\* (field), **annotation**\* (assembly), link\* (field), part\* (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_control-id" class="matched-1 same">
+            <summary>
+               <code>control-id</code>: Control ID</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_with-child-controls" class="matched-1 same">
+            <summary>
+               <code>with-child-controls</code>: Include contained controls with control</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_pattern" class="matched-1 same">
+            <summary>
+               <code>pattern</code>: Pattern</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_order" class="matched-1 same">
+            <summary>
+               <code>order</code>: Order</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+      </div>
+   </body>
+</html>

--- a/toolchains/xslt-proto-v04/compare/m2-m3-ssp-comparison.html
+++ b/toolchains/xslt-proto-v04/compare/m2-m3-ssp-comparison.html
@@ -1,31 +1,34 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
    <style type="text/css">
 
+body &gt; * { margin-top: 1ex }
+details { padding: 0.5ex; border: thin solid black; margin-top: 0.5ex }
+
 .brief { font-size: smaller; border: thin solid black; padding: 1ex }
 
-.same    { background-color: grey }
 .changed { background-color: pink }
 .new     { background-color: lemonchiffon }
 
 .same h4 { display: none }
+
 
 .label { font-family: sans-serif; font-weight: bold; font-size: 80% }
 
             </style>
    <body>
       <div class="summary">
-         <p class="brief">Comparing oscal-ssp:1.0.0-milestone3 ('\[M3]') with oscal-ssp:1.0.0-milestone2 ('\[M2]') </p>
+         <p class="brief">Comparing oscal-ssp:1.0.0-milestone3 ('Milestone 3 [M3]') with oscal-ssp:1.0.0-milestone2 ('Milestone 2 [M2]') </p>
          <div>
-            <h5>Found in \[M2] not \[M3]: party-id, person, org, person-id, org-id, person-name, org-name, target, service, interconnection, remote-system-name, set-param </h5>
+            <h5>Found in Milestone 2 [M2] not Milestone 3 [M3]: party-id, person, org, person-id, org-id, person-name, org-name, target, service, interconnection, remote-system-name, set-param </h5>
          </div>
          <div>
-            <h5>Found in \[M3] not \[M2]: revision, location, location-uuid, party-uuid, external-id, member-of-organization, party-name, text, biblio, uuid, set-parameter </h5>
+            <h5>Found in Milestone 3 [M3] not Milestone 2 [M2]: revision, location, location-uuid, party-uuid, external-id, member-of-organization, party-name, text, biblio, uuid, set-parameter </h5>
          </div>
          <div>
-            <h5>Assemblies in \[M2]: metadata back-matter annotation party person org rlink address resource role responsible-party citation system-security-plan import-profile system-characteristics system-information information-type confidentiality-impact integrity-impact availability-impact security-impact-level status leveraged-authorization authorization-boundary diagram network-architecture data-flow system-implementation user authorized-privilege component service protocol interconnection system-inventory inventory-item implemented-component control-implementation implemented-requirement statement responsible-role by-component set-param </h5>
+            <h5>Assemblies in Milestone 2 [M2]: metadata back-matter annotation party person org rlink address resource role responsible-party citation system-security-plan import-profile system-characteristics system-information information-type confidentiality-impact integrity-impact availability-impact security-impact-level status leveraged-authorization authorization-boundary diagram network-architecture data-flow system-implementation user authorized-privilege component service protocol interconnection system-inventory inventory-item implemented-component control-implementation implemented-requirement statement responsible-role by-component set-param </h5>
          </div>
          <div>
-            <h5>Assemblies in \[M3]: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party system-security-plan import-profile system-characteristics system-information information-type confidentiality-impact integrity-impact availability-impact security-impact-level status leveraged-authorization authorization-boundary diagram network-architecture data-flow system-implementation user authorized-privilege component protocol system-inventory inventory-item implemented-component control-implementation implemented-requirement statement responsible-role by-component set-parameter </h5>
+            <h5>Assemblies in Milestone 3 [M3]: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party system-security-plan import-profile system-characteristics system-information information-type confidentiality-impact integrity-impact availability-impact security-impact-level status leveraged-authorization authorization-boundary diagram network-architecture data-flow system-implementation user authorized-privilege component protocol system-inventory inventory-item implemented-component control-implementation implemented-requirement statement responsible-role by-component set-parameter </h5>
          </div>
          <div>
             <h5>Assemblies in either/both: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party system-security-plan import-profile system-characteristics system-information information-type confidentiality-impact integrity-impact availability-impact security-impact-level status leveraged-authorization authorization-boundary diagram network-architecture data-flow system-implementation user authorized-privilege component protocol system-inventory inventory-item implemented-component control-implementation implemented-requirement statement responsible-role by-component set-parameter person org service interconnection set-param </h5>
@@ -34,1498 +37,1346 @@
          <p class="short-name">oscal-ssp</p>
          <details id="assembly_metadata" class="matched-1 changed">
             <summary>
-               <code>metadata</code>: Publication metadata</summary>
+               <code>metadata</code>: Publication metadata  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), **revision**\* (assembly), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), **location**\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), **revision**\* (assembly), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), **location**\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_back-matter" class="matched-1 changed">
             <summary>
-               <code>back-matter</code>: Back matter</summary>
+               <code>back-matter</code>: Back matter  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>, *citation*\* (assembly), resource\* (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>, *citation*\* (assembly), resource\* (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>, resource\* (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>, resource\* (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_revision" class="matched-0 new">
             <summary>
-               <code>revision</code>: Revision History Entry</summary>
+               <code>revision</code>: Revision History Entry  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] model: </span>
-                  </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title**? (field), **published**? (field), **last-modified**? (field), **version**? (field), **oscal-version**? (field), **prop**\* (field), **link**\* (field), **remarks**? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), **published**? (field), **last-modified**? (field), **version**? (field), **oscal-version**? (field), **prop**\* (field), **link**\* (field), **remarks**? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_link" class="matched-1 same">
             <summary>
-               <code>link</code>: Link</summary>
+               <code>link</code>: Link  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>href? (flag), rel? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>href?, rel?, media-type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>href? (flag), rel? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>href?, rel?, media-type?</p>
                </div>
             </div>
          </details>
          <details id="assembly_published" class="matched-1 same">
             <summary>
-               <code>published</code>: Publication Timestamp</summary>
+               <code>published</code>: Publication Timestamp  with value type dateTime-with-timezone </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_last-modified" class="matched-1 same">
             <summary>
-               <code>last-modified</code>: Last modified timestamp</summary>
+               <code>last-modified</code>: Last modified timestamp  with value type dateTime-with-timezone </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_version" class="matched-1 same">
             <summary>
-               <code>version</code>: Document version</summary>
+               <code>version</code>: Document version  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_oscal-version" class="matched-1 same">
             <summary>
-               <code>oscal-version</code>: OSCAL version</summary>
+               <code>oscal-version</code>: OSCAL version  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_doc-id" class="matched-1 same">
             <summary>
-               <code>doc-id</code>: Document Identifier</summary>
+               <code>doc-id</code>: Document Identifier  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>type?</p>
                </div>
             </div>
          </details>
-         <details id="assembly_type" class="matched-1 same">
+         <details id="flag_type" class="matched-1 same">
             <summary>
-               <code>type</code>: Type</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>type</code>: Type  as type string </summary>
          </details>
          <details id="assembly_prop" class="matched-1 same">
             <summary>
-               <code>prop</code>: Property</summary>
+               <code>prop</code>: Property  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>name? (flag), id? (flag), ns? (flag), class? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>name?, id?, ns?, class?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>name? (flag), id? (flag), ns? (flag), class? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>name?, id?, ns?, class?</p>
                </div>
             </div>
          </details>
          <details id="assembly_annotation" class="matched-1 same">
             <summary>
-               <code>annotation</code>: Annotation</summary>
+               <code>annotation</code>: Annotation  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>name? (flag), id? (flag), ns? (flag), value? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>name?, id?, ns?, value?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>name? (flag), id? (flag), ns? (flag), value? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>name?, id?, ns?, value?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>remarks? (field)</p>
                </div>
             </div>
          </details>
-         <details id="assembly_name" class="matched-1 same">
+         <details id="flag_name" class="matched-1 same">
             <summary>
-               <code>name</code>: Name</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>name</code>: Name  as type NCName </summary>
          </details>
-         <details id="assembly_ns" class="matched-1 same">
+         <details id="flag_ns" class="matched-1 same">
             <summary>
-               <code>ns</code>: Namespace</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>ns</code>: Namespace  as type string </summary>
          </details>
-         <details id="assembly_class" class="matched-1 same">
+         <details id="flag_class" class="matched-1 same">
             <summary>
-               <code>class</code>: Class</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>class</code>: Class  as type NCName </summary>
          </details>
          <details id="assembly_location" class="matched-0 new">
             <summary>
-               <code>location</code>: Location</summary>
+               <code>location</code>: Location  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
                </div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] model: </span>
-                  </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title**? (field), **address** (assembly), **email**\* (field), **phone**\* (field), **url**\* (field), **prop**\* (field), **annotation**\* (assembly), **link**\* (field), **remarks**? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), **address** (assembly), **email**\* (field), **phone**\* (field), **url**\* (field), **prop**\* (field), **annotation**\* (assembly), **link**\* (field), **remarks**? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_location-uuid" class="matched-0 new">
             <summary>
-               <code>location-uuid</code>: Location Reference</summary>
+               <code>location-uuid</code>: Location Reference  with value type uuid </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_party" class="matched-1 changed">
             <summary>
-               <code>party</code>: Party (organization or person)</summary>
+               <code>party</code>: Party (organization or person)  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>**uuid**? (flag), **type**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>**uuid**?, **type**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>*person*\* (assembly), *org*? (assembly), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>*person*\* (assembly), *org*? (assembly), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**party-name** (field), **short-name**? (field), **external-id**\* (field), prop\* (field), annotation\* (assembly), link\* (field), **address**\* (assembly), **email**\* (field), **phone**\* (field), **member-of-organization**\* (field), **location-uuid**\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**party-name** (field), **short-name**? (field), **external-id**\* (field), prop\* (field), annotation\* (assembly), link\* (field), **address**\* (assembly), **email**\* (field), **phone**\* (field), **member-of-organization**\* (field), **location-uuid**\* (field), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_party-uuid" class="matched-0 new">
             <summary>
-               <code>party-uuid</code>: Party Reference</summary>
+               <code>party-uuid</code>: Party Reference  with value type uuid </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_external-id" class="matched-0 new">
             <summary>
-               <code>external-id</code>: Personal Identifier</summary>
+               <code>external-id</code>: Personal Identifier  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**type**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**type**?</p>
                </div>
             </div>
          </details>
          <details id="assembly_member-of-organization" class="matched-0 new">
             <summary>
-               <code>member-of-organization</code>: Organizational Affiliation</summary>
+               <code>member-of-organization</code>: Organizational Affiliation  with value type uuid </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_rlink" class="matched-1 same">
             <summary>
-               <code>rlink</code>: Resource link</summary>
+               <code>rlink</code>: Resource link  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>href? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>href?, media-type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>href? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>href?, media-type?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>hash\* (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>hash\* (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>hash\* (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>hash\* (field)</p>
                </div>
             </div>
          </details>
-         <details id="assembly_rel" class="matched-1 same">
+         <details id="flag_rel" class="matched-1 same">
             <summary>
-               <code>rel</code>: Relation</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>rel</code>: Relation  as type NCName </summary>
          </details>
-         <details id="assembly_media-type" class="matched-1 same">
+         <details id="flag_media-type" class="matched-1 same">
             <summary>
-               <code>media-type</code>: Media type</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>media-type</code>: Media type  as type string </summary>
          </details>
          <details id="assembly_party-name" class="matched-0 new">
             <summary>
-               <code>party-name</code>: Party Name</summary>
+               <code>party-name</code>: Party Name  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_short-name" class="matched-1 same">
             <summary>
-               <code>short-name</code>: short-name</summary>
+               <code>short-name</code>: short-name  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_address" class="matched-1 same">
             <summary>
-               <code>address</code>: Address</summary>
+               <code>address</code>: Address  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>type?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_addr-line" class="matched-1 same">
             <summary>
-               <code>addr-line</code>: Address line</summary>
+               <code>addr-line</code>: Address line  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_city" class="matched-1 same">
             <summary>
-               <code>city</code>: City</summary>
+               <code>city</code>: City  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_state" class="matched-1 same">
             <summary>
-               <code>state</code>: State</summary>
+               <code>state</code>: State  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_postal-code" class="matched-1 same">
             <summary>
-               <code>postal-code</code>: Postal Code</summary>
+               <code>postal-code</code>: Postal Code  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_country" class="matched-1 same">
             <summary>
-               <code>country</code>: Country</summary>
+               <code>country</code>: Country  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_email" class="matched-1 same">
             <summary>
-               <code>email</code>: Email</summary>
+               <code>email</code>: Email  with value type email </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_phone" class="matched-1 same">
             <summary>
-               <code>phone</code>: Telephone</summary>
+               <code>phone</code>: Telephone  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>type?</p>
                </div>
             </div>
          </details>
          <details id="assembly_url" class="matched-1 same">
             <summary>
-               <code>url</code>: URL</summary>
+               <code>url</code>: URL  with value type uri </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_desc" class="matched-1 same">
             <summary>
-               <code>desc</code>: Description</summary>
+               <code>desc</code>: Description  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_text" class="matched-0 new">
             <summary>
-               <code>text</code>: Text</summary>
+               <code>text</code>: Text  with value type markup-line </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_biblio" class="matched-0 new">
             <summary>
-               <code>biblio</code>: Bibliographic Definition</summary>
+               <code>biblio</code>: Bibliographic Definition  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] model: </span>
-                  </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>? (any)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>? (any)</p>
                </div>
             </div>
          </details>
          <details id="assembly_resource" class="matched-1 changed">
             <summary>
-               <code>resource</code>: Resource</summary>
+               <code>resource</code>: Resource  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>desc? (field), prop\* (field)
+                     <span class="label">Milestone 2 [M2] model: </span>desc? (field), prop\* (field)
         (<i>A choice:</i>rlink\* (assembly), base64? (field)
             )
     , remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title**? (field), desc? (field), prop\* (field), **doc-id**\* (field), **citation**? (assembly), rlink\* (assembly), base64\* (field), remarks? (field), ? (any)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), desc? (field), prop\* (field), **doc-id**\* (field), **citation**? (assembly), rlink\* (assembly), base64\* (field), remarks? (field), ? (any)</p>
                </div>
             </div>
          </details>
          <details id="assembly_citation" class="matched-1 changed">
             <summary>
-               <code>citation</code>: Citation</summary>
+               <code>citation</code>: Citation  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>*target*\* (field), *title*? (field), *desc*? (field), *doc-id*\* (field), prop\* (field), ? (any)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>*target*\* (field), *title*? (field), *desc*? (field), *doc-id*\* (field), prop\* (field), ? (any)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**text** (field), prop\* (field), **biblio**? (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**text** (field), prop\* (field), **biblio**? (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_hash" class="matched-1 same">
             <summary>
-               <code>hash</code>: Hash</summary>
+               <code>hash</code>: Hash  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>algorithm? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>algorithm?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>algorithm? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>algorithm?</p>
                </div>
             </div>
          </details>
-         <details id="assembly_algorithm" class="matched-1 same">
+         <details id="flag_algorithm" class="matched-1 same">
             <summary>
-               <code>algorithm</code>: Hash algorithm</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>algorithm</code>: Hash algorithm  as type string </summary>
          </details>
          <details id="assembly_role" class="matched-1 same">
             <summary>
-               <code>role</code>: Role</summary>
+               <code>role</code>: Role  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_responsible-party" class="matched-1 changed">
             <summary>
-               <code>responsible-party</code>: Responsible Party</summary>
+               <code>responsible-party</code>: Responsible Party  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>role-id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>role-id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>role-id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>role-id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>*party-id** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>*party-id** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**party-uuid*** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**party-uuid*** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
                </div>
             </div>
          </details>
-         <details id="assembly_href" class="matched-1 same">
+         <details id="flag_href" class="matched-1 same">
             <summary>
-               <code>href</code>: hypertext reference</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>href</code>: hypertext reference  as type uri-reference </summary>
          </details>
-         <details id="assembly_id" class="matched-1 changed">
+         <details id="flag_id" class="matched-1 changed">
             <summary>
-               <code>id</code>: Identifier</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>id</code>: Identifier  as type NCName </summary>
          </details>
-         <details id="assembly_uuid" class="matched-0 new">
+         <details id="flag_uuid" class="matched-0 new">
             <summary>
-               <code>uuid</code>: Universally Unique Identifier</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>uuid</code>: Universally Unique Identifier  as type uuid </summary>
          </details>
          <details id="assembly_title" class="matched-1 same">
             <summary>
-               <code>title</code>: Title</summary>
+               <code>title</code>: Title  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_base64" class="matched-1 same">
             <summary>
-               <code>base64</code>: Base64</summary>
+               <code>base64</code>: Base64  with value type base64Binary </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>filename? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>filename?, media-type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>filename? (flag), media-type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>filename?, media-type?</p>
                </div>
             </div>
          </details>
-         <details id="assembly_filename" class="matched-1 same">
+         <details id="flag_filename" class="matched-1 same">
             <summary>
-               <code>filename</code>: File Name</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>filename</code>: File Name  as type uri-reference </summary>
          </details>
          <details id="assembly_description" class="matched-1 same">
             <summary>
-               <code>description</code>: Description</summary>
+               <code>description</code>: Description  with value type markup-multiline </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_remarks" class="matched-1 same">
             <summary>
-               <code>remarks</code>: Remarks</summary>
+               <code>remarks</code>: Remarks  with value type markup-multiline </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
-         <details id="assembly_component-type" class="matched-1 same">
+         <details id="flag_component-type" class="matched-1 same">
             <summary>
-               <code>component-type</code>: Component Type</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>component-type</code>: Component Type  as type string </summary>
          </details>
-         <details id="assembly_control-id" class="matched-1 same">
+         <details id="flag_control-id" class="matched-1 same">
             <summary>
-               <code>control-id</code>: Control Identifier Reference</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>control-id</code>: Control Identifier Reference  as type NCName </summary>
          </details>
-         <details id="assembly_statement-id" class="matched-1 same">
+         <details id="flag_statement-id" class="matched-1 same">
             <summary>
-               <code>statement-id</code>: Control Statement Reference</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>statement-id</code>: Control Statement Reference  as type NCName </summary>
          </details>
-         <details id="assembly_system-security-plan" class="matched-1 same">
+         <details id="assembly_system-security-plan" class="matched-1 changed">
             <summary>
-               <code>system-security-plan</code>: System Security Plan (SSP)</summary>
+               <code>system-security-plan</code>: System Security Plan (SSP)  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>metadata? (assembly), import-profile (assembly), system-characteristics (assembly), system-implementation? (assembly), control-implementation? (assembly), back-matter? (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>metadata? (assembly), import-profile (assembly), system-characteristics (assembly), system-implementation? (assembly), control-implementation? (assembly), back-matter? (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>metadata (assembly), import-profile (assembly), system-characteristics (assembly), system-implementation (assembly), control-implementation (assembly), back-matter? (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>metadata (assembly), import-profile (assembly), system-characteristics (assembly), system-implementation (assembly), control-implementation (assembly), back-matter? (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_import-profile" class="matched-1 same">
             <summary>
-               <code>import-profile</code>: Import Profile</summary>
+               <code>import-profile</code>: Import Profile  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>href? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>href?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>href? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>href?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_system-characteristics" class="matched-1 changed">
             <summary>
-               <code>system-characteristics</code>: System Characteristics</summary>
+               <code>system-characteristics</code>: System Characteristics  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>system-id* (field), system-name (field), system-name-short? (field), description (field), prop\* (field), annotation\* (assembly), link\* (field), date-authorized? (field), security-sensitivity-level (field), system-information (assembly), security-impact-level (assembly), status (assembly), *leveraged-authorization*\* (assembly), authorization-boundary (assembly), network-architecture? (assembly), data-flow? (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>system-id* (field), system-name (field), system-name-short? (field), description (field), prop\* (field), annotation\* (assembly), link\* (field), date-authorized? (field), security-sensitivity-level (field), system-information (assembly), security-impact-level (assembly), status (assembly), *leveraged-authorization*\* (assembly), authorization-boundary (assembly), network-architecture? (assembly), data-flow? (assembly), responsible-party\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>system-id* (field), system-name (field), system-name-short? (field), description (field), prop\* (field), annotation\* (assembly), link\* (field), date-authorized? (field), security-sensitivity-level (field), system-information (assembly), security-impact-level (assembly), status (assembly), authorization-boundary (assembly), network-architecture? (assembly), data-flow? (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>system-id* (field), system-name (field), system-name-short? (field), description (field), prop\* (field), annotation\* (assembly), link\* (field), date-authorized? (field), security-sensitivity-level (field), system-information (assembly), security-impact-level (assembly), status (assembly), authorization-boundary (assembly), network-architecture? (assembly), data-flow? (assembly), responsible-party\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_system-id" class="matched-1 same">
             <summary>
-               <code>system-id</code>: System Identification</summary>
+               <code>system-id</code>: System Identification  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>identifier-type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>identifier-type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>identifier-type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>identifier-type?</p>
                </div>
             </div>
          </details>
          <details id="assembly_system-name" class="matched-1 same">
             <summary>
-               <code>system-name</code>: System Name (Full)</summary>
+               <code>system-name</code>: System Name (Full)  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_system-name-short" class="matched-1 same">
             <summary>
-               <code>system-name-short</code>: System Name (Short)</summary>
+               <code>system-name-short</code>: System Name (Short)  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_security-sensitivity-level" class="matched-1 same">
             <summary>
-               <code>security-sensitivity-level</code>: Security Sensitivity Level</summary>
+               <code>security-sensitivity-level</code>: Security Sensitivity Level  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_system-information" class="matched-1 same">
             <summary>
-               <code>system-information</code>: System Information</summary>
+               <code>system-information</code>: System Information  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), information-type* (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), information-type* (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), information-type* (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), information-type* (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_information-type" class="matched-1 changed">
             <summary>
-               <code>information-type</code>: Information Type</summary>
+               <code>information-type</code>: Information Type  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>id? (flag), *name*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>id?, *name*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description (field), information-type-id\* (field), prop\* (field), confidentiality-impact (assembly), integrity-impact (assembly), availability-impact (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description (field), information-type-id\* (field), prop\* (field), confidentiality-impact (assembly), integrity-impact (assembly), availability-impact (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title** (field), description (field), information-type-id\* (field), prop\* (field), confidentiality-impact (assembly), integrity-impact (assembly), availability-impact (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title** (field), description (field), information-type-id\* (field), prop\* (field), confidentiality-impact (assembly), integrity-impact (assembly), availability-impact (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_information-type-id" class="matched-1 same">
             <summary>
-               <code>information-type-id</code>: Information Type Identifier</summary>
+               <code>information-type-id</code>: Information Type Identifier  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>system? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>system?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>system? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>system?</p>
                </div>
             </div>
          </details>
          <details id="assembly_confidentiality-impact" class="matched-1 same">
             <summary>
-               <code>confidentiality-impact</code>: Confidentiality Impact Level</summary>
+               <code>confidentiality-impact</code>: Confidentiality Impact Level  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_integrity-impact" class="matched-1 same">
             <summary>
-               <code>integrity-impact</code>: Integrity Impact Level</summary>
+               <code>integrity-impact</code>: Integrity Impact Level  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_availability-impact" class="matched-1 same">
             <summary>
-               <code>availability-impact</code>: Availability Impact Level</summary>
+               <code>availability-impact</code>: Availability Impact Level  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_base" class="matched-1 same">
             <summary>
-               <code>base</code>: Base Level (Confidentiality, Integrity, or Availability)</summary>
+               <code>base</code>: Base Level (Confidentiality, Integrity, or Availability)  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_selected" class="matched-1 same">
             <summary>
-               <code>selected</code>: Selected Level (Confidentiality, Integrity, or Availability)</summary>
+               <code>selected</code>: Selected Level (Confidentiality, Integrity, or Availability)  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_adjustment-justification" class="matched-1 same">
             <summary>
-               <code>adjustment-justification</code>: Adjustment Justification</summary>
+               <code>adjustment-justification</code>: Adjustment Justification  with value type markup-multiline </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_security-impact-level" class="matched-1 same">
             <summary>
-               <code>security-impact-level</code>: Security Impact Level</summary>
+               <code>security-impact-level</code>: Security Impact Level  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>security-objective-confidentiality? (field), security-objective-integrity? (field), security-objective-availability? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>security-objective-confidentiality? (field), security-objective-integrity? (field), security-objective-availability? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>security-objective-confidentiality? (field), security-objective-integrity? (field), security-objective-availability? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>security-objective-confidentiality? (field), security-objective-integrity? (field), security-objective-availability? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_security-objective-confidentiality" class="matched-1 same">
             <summary>
-               <code>security-objective-confidentiality</code>: Security Objective: Confidentiality</summary>
+               <code>security-objective-confidentiality</code>: Security Objective: Confidentiality  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_security-objective-integrity" class="matched-1 same">
             <summary>
-               <code>security-objective-integrity</code>: Security Objective: Integrity</summary>
+               <code>security-objective-integrity</code>: Security Objective: Integrity  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_security-objective-availability" class="matched-1 same">
             <summary>
-               <code>security-objective-availability</code>: Security Objective: Availability</summary>
+               <code>security-objective-availability</code>: Security Objective: Availability  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_status" class="matched-1 same">
             <summary>
-               <code>status</code>: Status</summary>
+               <code>status</code>: Status  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>state? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>state?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>state? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>state?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_leveraged-authorization" class="matched-1 changed">
             <summary>
-               <code>leveraged-authorization</code>: Leveraged Authorization</summary>
+               <code>leveraged-authorization</code>: Leveraged Authorization  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>id? (flag), *name*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>id?, *name*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), *party-id* (field), date-authorized (field), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), *party-id* (field), date-authorized (field), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title** (field), prop\* (field), annotation\* (assembly), link\* (field), **party-uuid** (field), date-authorized (field), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title** (field), prop\* (field), annotation\* (assembly), link\* (field), **party-uuid** (field), date-authorized (field), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_date-authorized" class="matched-1 same">
             <summary>
-               <code>date-authorized</code>: System Authorization Date</summary>
+               <code>date-authorized</code>: System Authorization Date  with value type date </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_authorization-boundary" class="matched-1 same">
             <summary>
-               <code>authorization-boundary</code>: Authorization Boundary</summary>
+               <code>authorization-boundary</code>: Authorization Boundary  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_diagram" class="matched-1 changed">
             <summary>
-               <code>diagram</code>: Diagram</summary>
+               <code>diagram</code>: Diagram  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description? (field), prop\* (field), link\* (field), caption? (field), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description? (field), prop\* (field), link\* (field), caption? (field), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>description? (field), prop\* (field), link\* (field), caption? (field), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>description? (field), prop\* (field), link\* (field), caption? (field), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_caption" class="matched-1 same">
             <summary>
-               <code>caption</code>: Caption</summary>
+               <code>caption</code>: Caption  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_network-architecture" class="matched-1 same">
             <summary>
-               <code>network-architecture</code>: Network Architecture</summary>
+               <code>network-architecture</code>: Network Architecture  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_data-flow" class="matched-1 same">
             <summary>
-               <code>data-flow</code>: Data Flow</summary>
+               <code>data-flow</code>: Data Flow  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_system-implementation" class="matched-1 changed">
             <summary>
-               <code>system-implementation</code>: System Implementation</summary>
+               <code>system-implementation</code>: System Implementation  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), user* (assembly), component\* (assembly), *service*\* (assembly), *interconnection*\* (assembly), system-inventory? (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), user* (assembly), component\* (assembly), *service*\* (assembly), *interconnection*\* (assembly), system-inventory? (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), **leveraged-authorization**\* (assembly), user* (assembly), component\* (assembly), system-inventory? (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), **leveraged-authorization**\* (assembly), user* (assembly), component\* (assembly), system-inventory? (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_user" class="matched-1 changed">
             <summary>
-               <code>user</code>: System User Class</summary>
+               <code>user</code>: System User Class  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*id*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**uuid**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>title? (field), short-name? (field), description? (field), prop\* (field), annotation\* (assembly), link\* (field), role-id* (field), authorized-privilege\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>title? (field), short-name? (field), description? (field), prop\* (field), annotation\* (assembly), link\* (field), role-id* (field), authorized-privilege\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>title? (field), short-name? (field), description? (field), prop\* (field), annotation\* (assembly), link\* (field), role-id* (field), authorized-privilege\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>title? (field), short-name? (field), description? (field), prop\* (field), annotation\* (assembly), link\* (field), role-id* (field), authorized-privilege\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_role-id" class="matched-1 changed">
             <summary>
-               <code>role-id</code>: Role Identifier Reference</summary>
+               <code>role-id</code>: Role Identifier Reference  with value type NCName </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_authorized-privilege" class="matched-1 changed">
             <summary>
-               <code>authorized-privilege</code>: Privilege</summary>
+               <code>authorized-privilege</code>: Privilege  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>*name*? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>*name*?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description? (field), function-performed* (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description? (field), function-performed* (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title** (field), description? (field), function-performed* (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title** (field), description? (field), function-performed* (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_function-performed" class="matched-1 same">
             <summary>
-               <code>function-performed</code>: Functions Performed</summary>
+               <code>function-performed</code>: Functions Performed  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_component" class="matched-1 changed">
             <summary>
-               <code>component</code>: Component</summary>
+               <code>component</code>: Component  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>*id*? (flag), name? (flag), component-type? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>*id*?, name?, component-type?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>**uuid**? (flag), component-type? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>**uuid**?, component-type?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), status (assembly), responsible-role\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), status (assembly), responsible-role\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title** (field), description (field), **purpose**? (field), prop\* (field), annotation\* (assembly), link\* (field), status (assembly), responsible-role\* (assembly), **protocol**\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title** (field), description (field), **purpose**? (field), prop\* (field), annotation\* (assembly), link\* (field), status (assembly), responsible-role\* (assembly), **protocol**\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_protocol" class="matched-1 changed">
             <summary>
-               <code>protocol</code>: Protocol</summary>
+               <code>protocol</code>: Protocol  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>name? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>name?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>**uuid**? (flag), name? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>**uuid**?, name?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>port-range\* (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>port-range\* (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**title**? (field), port-range\* (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**title**? (field), port-range\* (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_port-range" class="matched-1 same">
             <summary>
-               <code>port-range</code>: Port Range</summary>
+               <code>port-range</code>: Port Range  with value type empty </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>start? (flag), end? (flag), transport? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>start?, end?, transport?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>start? (flag), end? (flag), transport? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>start?, end?, transport?</p>
                </div>
             </div>
          </details>
          <details id="assembly_purpose" class="matched-1 same">
             <summary>
-               <code>purpose</code>: Purpose</summary>
+               <code>purpose</code>: Purpose  with value type markup-line </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
          <details id="assembly_system-inventory" class="matched-1 same">
             <summary>
-               <code>system-inventory</code>: System Inventory</summary>
+               <code>system-inventory</code>: System Inventory  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>inventory-item* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>inventory-item* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>inventory-item* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>inventory-item* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_inventory-item" class="matched-1 changed">
             <summary>
-               <code>inventory-item</code>: Inventory Item</summary>
+               <code>inventory-item</code>: Inventory Item  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>*id*? (flag), asset-id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>*id*?, asset-id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>**uuid**? (flag), asset-id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>**uuid**?, asset-id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), implemented-component\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), implemented-component\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), implemented-component\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), implemented-component\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_implemented-component" class="matched-1 same">
             <summary>
-               <code>implemented-component</code>: Implemented Component</summary>
+               <code>implemented-component</code>: Implemented Component  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>component-id? (flag), use? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>component-id?, use?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>component-id? (flag), use? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>component-id?, use?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_control-implementation" class="matched-1 same">
             <summary>
-               <code>control-implementation</code>: Control Implementation</summary>
+               <code>control-implementation</code>: Control Implementation  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description (field), implemented-requirement* (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description (field), implemented-requirement* (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>description (field), implemented-requirement* (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>description (field), implemented-requirement* (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_implemented-requirement" class="matched-1 changed">
             <summary>
-               <code>implemented-requirement</code>: Control-based Requirement</summary>
+               <code>implemented-requirement</code>: Control-based Requirement  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flags: </span>*id*? (flag), control-id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flags: </span>*id*?, control-id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>**uuid**? (flag), control-id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>**uuid**?, control-id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description? (field), prop\* (field), annotation\* (assembly), link\* (field), by-component\* (assembly), responsible-role\* (assembly), *set-param*\* (assembly), statement\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description? (field), prop\* (field), annotation\* (assembly), link\* (field), by-component\* (assembly), responsible-role\* (assembly), *set-param*\* (assembly), statement\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>description? (field), prop\* (field), annotation\* (assembly), link\* (field), by-component\* (assembly), responsible-role\* (assembly), **set-parameter**\* (assembly), statement\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>description? (field), prop\* (field), annotation\* (assembly), link\* (field), by-component\* (assembly), responsible-role\* (assembly), **set-parameter**\* (assembly), statement\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_statement" class="matched-1 changed">
             <summary>
-               <code>statement</code>: Specific Statement</summary>
+               <code>statement</code>: Specific Statement  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>statement-id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>statement-id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>statement-id? (flag), **uuid**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>statement-id?, **uuid**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description? (field), prop\* (field), link\* (field), responsible-role\* (assembly), by-component\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description? (field), prop\* (field), link\* (field), responsible-role\* (assembly), by-component\* (assembly), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>description? (field), prop\* (field), **annotation**\* (assembly), link\* (field), responsible-role\* (assembly), by-component\* (assembly), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>description? (field), prop\* (field), **annotation**\* (assembly), link\* (field), responsible-role\* (assembly), by-component\* (assembly), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_responsible-role" class="matched-1 changed">
             <summary>
-               <code>responsible-role</code>: Responsible Role</summary>
+               <code>responsible-role</code>: Responsible Role  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>role-id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>role-id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>role-id? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>role-id?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), *party-id*\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), *party-id*\* (field), remarks? (field)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), **party-uuid**\* (field), remarks? (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), **party-uuid**\* (field), remarks? (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_by-component" class="matched-1 changed">
             <summary>
-               <code>by-component</code>: Component Control Implementation</summary>
+               <code>by-component</code>: Component Control Implementation  </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span>component-id? (flag)</p>
+                     <span class="label">Milestone 2 [M2] flag: </span>component-id?</p>
                   <p class="now">
-                     <span class="label">\[M3] flags: </span>component-id? (flag), **uuid**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flags: </span>component-id?, **uuid**?</p>
                </div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-role\* (assembly), *set-param*\* (assembly)</p>
+                     <span class="label">Milestone 2 [M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-role\* (assembly), *set-param*\* (assembly)</p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-role\* (assembly), **set-parameter**\* (assembly)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-role\* (assembly), **set-parameter**\* (assembly)</p>
                </div>
             </div>
          </details>
          <details id="assembly_set-parameter" class="matched-0 new">
             <summary>
-               <code>set-parameter</code>: Set Parameter Value</summary>
+               <code>set-parameter</code>: Set Parameter Value  </summary>
             <div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span>**param-id**? (flag)</p>
+                     <span class="label">Milestone 3 [M3] flag: </span>**param-id**?</p>
                </div>
                <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] model: </span>
-                  </p>
                   <p class="now">
-                     <span class="label">\[M3] model: </span>**value** (field)</p>
+                     <span class="label">Milestone 3 [M3] model: </span>**value** (field)</p>
                </div>
             </div>
          </details>
          <details id="assembly_value" class="matched-1 same">
             <summary>
-               <code>value</code>: Value</summary>
+               <code>value</code>: Value  with value type string </summary>
             <div>
                <div class="comparison">
                   <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
+                     <span class="label">Milestone 2 [M2] flags: </span> [none]</p>
                   <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
+                     <span class="label">Milestone 3 [M3] flags: </span> [none]</p>
                </div>
             </div>
          </details>
-         <details id="assembly_param-id" class="matched-1 same">
+         <details id="flag_param-id" class="matched-1 same">
             <summary>
-               <code>param-id</code>: Parameter ID</summary>
-            <div>
-               <div class="comparison">
-                  <p class="was">
-                     <span class="label">\[M2] flag: </span> [none]</p>
-                  <p class="now">
-                     <span class="label">\[M3] flag: </span> [none]</p>
-               </div>
-            </div>
+               <code>param-id</code>: Parameter ID  as type NCName </summary>
          </details>
       </div>
    </body>

--- a/toolchains/xslt-proto-v04/compare/m2-m3-ssp-comparison.html
+++ b/toolchains/xslt-proto-v04/compare/m2-m3-ssp-comparison.html
@@ -1,0 +1,1532 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+   <style type="text/css">
+
+.brief { font-size: smaller; border: thin solid black; padding: 1ex }
+
+.same    { background-color: grey }
+.changed { background-color: pink }
+.new     { background-color: lemonchiffon }
+
+.same h4 { display: none }
+
+.label { font-family: sans-serif; font-weight: bold; font-size: 80% }
+
+            </style>
+   <body>
+      <div class="summary">
+         <p class="brief">Comparing oscal-ssp:1.0.0-milestone3 ('\[M3]') with oscal-ssp:1.0.0-milestone2 ('\[M2]') </p>
+         <div>
+            <h5>Found in \[M2] not \[M3]: party-id, person, org, person-id, org-id, person-name, org-name, target, service, interconnection, remote-system-name, set-param </h5>
+         </div>
+         <div>
+            <h5>Found in \[M3] not \[M2]: revision, location, location-uuid, party-uuid, external-id, member-of-organization, party-name, text, biblio, uuid, set-parameter </h5>
+         </div>
+         <div>
+            <h5>Assemblies in \[M2]: metadata back-matter annotation party person org rlink address resource role responsible-party citation system-security-plan import-profile system-characteristics system-information information-type confidentiality-impact integrity-impact availability-impact security-impact-level status leveraged-authorization authorization-boundary diagram network-architecture data-flow system-implementation user authorized-privilege component service protocol interconnection system-inventory inventory-item implemented-component control-implementation implemented-requirement statement responsible-role by-component set-param </h5>
+         </div>
+         <div>
+            <h5>Assemblies in \[M3]: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party system-security-plan import-profile system-characteristics system-information information-type confidentiality-impact integrity-impact availability-impact security-impact-level status leveraged-authorization authorization-boundary diagram network-architecture data-flow system-implementation user authorized-privilege component protocol system-inventory inventory-item implemented-component control-implementation implemented-requirement statement responsible-role by-component set-parameter </h5>
+         </div>
+         <div>
+            <h5>Assemblies in either/both: metadata back-matter revision annotation location party rlink address biblio resource citation role responsible-party system-security-plan import-profile system-characteristics system-information information-type confidentiality-impact integrity-impact availability-impact security-impact-level status leveraged-authorization authorization-boundary diagram network-architecture data-flow system-implementation user authorized-privilege component protocol system-inventory inventory-item implemented-component control-implementation implemented-requirement statement responsible-role by-component set-parameter person org service interconnection set-param </h5>
+         </div>
+         <p class="schema-name">OSCAL System Security Plan (SSP) Format</p>
+         <p class="short-name">oscal-ssp</p>
+         <details id="assembly_metadata" class="matched-1 changed">
+            <summary>
+               <code>metadata</code>: Publication metadata</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>title (field), published? (field), last-modified (field), version (field), oscal-version (field), **revision**\* (assembly), doc-id\* (field), prop\* (field), link\* (field), role\* (assembly), **location**\* (assembly), party\* (assembly), responsible-party\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_back-matter" class="matched-1 changed">
+            <summary>
+               <code>back-matter</code>: Back matter</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>, *citation*\* (assembly), resource\* (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>, resource\* (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_revision" class="matched-0 new">
+            <summary>
+               <code>revision</code>: Revision History Entry</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+                  </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title**? (field), **published**? (field), **last-modified**? (field), **version**? (field), **oscal-version**? (field), **prop**\* (field), **link**\* (field), **remarks**? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_link" class="matched-1 same">
+            <summary>
+               <code>link</code>: Link</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>href? (flag), rel? (flag), media-type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>href? (flag), rel? (flag), media-type? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_published" class="matched-1 same">
+            <summary>
+               <code>published</code>: Publication Timestamp</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_last-modified" class="matched-1 same">
+            <summary>
+               <code>last-modified</code>: Last modified timestamp</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_version" class="matched-1 same">
+            <summary>
+               <code>version</code>: Document version</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_oscal-version" class="matched-1 same">
+            <summary>
+               <code>oscal-version</code>: OSCAL version</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_doc-id" class="matched-1 same">
+            <summary>
+               <code>doc-id</code>: Document Identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_type" class="matched-1 same">
+            <summary>
+               <code>type</code>: Type</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_prop" class="matched-1 same">
+            <summary>
+               <code>prop</code>: Property</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>name? (flag), id? (flag), ns? (flag), class? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>name? (flag), id? (flag), ns? (flag), class? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_annotation" class="matched-1 same">
+            <summary>
+               <code>annotation</code>: Annotation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>name? (flag), id? (flag), ns? (flag), value? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>name? (flag), id? (flag), ns? (flag), value? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_name" class="matched-1 same">
+            <summary>
+               <code>name</code>: Name</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_ns" class="matched-1 same">
+            <summary>
+               <code>ns</code>: Namespace</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_class" class="matched-1 same">
+            <summary>
+               <code>class</code>: Class</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_location" class="matched-0 new">
+            <summary>
+               <code>location</code>: Location</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+                  </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title**? (field), **address** (assembly), **email**\* (field), **phone**\* (field), **url**\* (field), **prop**\* (field), **annotation**\* (assembly), **link**\* (field), **remarks**? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_location-uuid" class="matched-0 new">
+            <summary>
+               <code>location-uuid</code>: Location Reference</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_party" class="matched-1 changed">
+            <summary>
+               <code>party</code>: Party (organization or person)</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>**uuid**? (flag), **type**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>*person*\* (assembly), *org*? (assembly), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**party-name** (field), **short-name**? (field), **external-id**\* (field), prop\* (field), annotation\* (assembly), link\* (field), **address**\* (assembly), **email**\* (field), **phone**\* (field), **member-of-organization**\* (field), **location-uuid**\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_party-uuid" class="matched-0 new">
+            <summary>
+               <code>party-uuid</code>: Party Reference</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_external-id" class="matched-0 new">
+            <summary>
+               <code>external-id</code>: Personal Identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**type**? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_member-of-organization" class="matched-0 new">
+            <summary>
+               <code>member-of-organization</code>: Organizational Affiliation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_rlink" class="matched-1 same">
+            <summary>
+               <code>rlink</code>: Resource link</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>href? (flag), media-type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>href? (flag), media-type? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>hash\* (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>hash\* (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_rel" class="matched-1 same">
+            <summary>
+               <code>rel</code>: Relation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_media-type" class="matched-1 same">
+            <summary>
+               <code>media-type</code>: Media type</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_party-name" class="matched-0 new">
+            <summary>
+               <code>party-name</code>: Party Name</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_short-name" class="matched-1 same">
+            <summary>
+               <code>short-name</code>: short-name</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_address" class="matched-1 same">
+            <summary>
+               <code>address</code>: Address</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>addr-line\* (field), city? (field), state? (field), postal-code? (field), country? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_addr-line" class="matched-1 same">
+            <summary>
+               <code>addr-line</code>: Address line</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_city" class="matched-1 same">
+            <summary>
+               <code>city</code>: City</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_state" class="matched-1 same">
+            <summary>
+               <code>state</code>: State</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_postal-code" class="matched-1 same">
+            <summary>
+               <code>postal-code</code>: Postal Code</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_country" class="matched-1 same">
+            <summary>
+               <code>country</code>: Country</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_email" class="matched-1 same">
+            <summary>
+               <code>email</code>: Email</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_phone" class="matched-1 same">
+            <summary>
+               <code>phone</code>: Telephone</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>type? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_url" class="matched-1 same">
+            <summary>
+               <code>url</code>: URL</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_desc" class="matched-1 same">
+            <summary>
+               <code>desc</code>: Description</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_text" class="matched-0 new">
+            <summary>
+               <code>text</code>: Text</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_biblio" class="matched-0 new">
+            <summary>
+               <code>biblio</code>: Bibliographic Definition</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+                  </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_resource" class="matched-1 changed">
+            <summary>
+               <code>resource</code>: Resource</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>desc? (field), prop\* (field)
+        (<i>A choice:</i>rlink\* (assembly), base64? (field)
+            )
+    , remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title**? (field), desc? (field), prop\* (field), **doc-id**\* (field), **citation**? (assembly), rlink\* (assembly), base64\* (field), remarks? (field), ? (any)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_citation" class="matched-1 changed">
+            <summary>
+               <code>citation</code>: Citation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>*target*\* (field), *title*? (field), *desc*? (field), *doc-id*\* (field), prop\* (field), ? (any)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**text** (field), prop\* (field), **biblio**? (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_hash" class="matched-1 same">
+            <summary>
+               <code>hash</code>: Hash</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>algorithm? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>algorithm? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_algorithm" class="matched-1 same">
+            <summary>
+               <code>algorithm</code>: Hash algorithm</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_role" class="matched-1 same">
+            <summary>
+               <code>role</code>: Role</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>title (field), short-name? (field), desc? (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_responsible-party" class="matched-1 changed">
+            <summary>
+               <code>responsible-party</code>: Responsible Party</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>role-id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>role-id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>*party-id** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**party-uuid*** (field), prop\* (field), annotation\* (assembly), link\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_href" class="matched-1 same">
+            <summary>
+               <code>href</code>: hypertext reference</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_id" class="matched-1 changed">
+            <summary>
+               <code>id</code>: Identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_uuid" class="matched-0 new">
+            <summary>
+               <code>uuid</code>: Universally Unique Identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_title" class="matched-1 same">
+            <summary>
+               <code>title</code>: Title</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_base64" class="matched-1 same">
+            <summary>
+               <code>base64</code>: Base64</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>filename? (flag), media-type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>filename? (flag), media-type? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_filename" class="matched-1 same">
+            <summary>
+               <code>filename</code>: File Name</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_description" class="matched-1 same">
+            <summary>
+               <code>description</code>: Description</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_remarks" class="matched-1 same">
+            <summary>
+               <code>remarks</code>: Remarks</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_component-type" class="matched-1 same">
+            <summary>
+               <code>component-type</code>: Component Type</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_control-id" class="matched-1 same">
+            <summary>
+               <code>control-id</code>: Control Identifier Reference</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_statement-id" class="matched-1 same">
+            <summary>
+               <code>statement-id</code>: Control Statement Reference</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_system-security-plan" class="matched-1 same">
+            <summary>
+               <code>system-security-plan</code>: System Security Plan (SSP)</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>metadata? (assembly), import-profile (assembly), system-characteristics (assembly), system-implementation? (assembly), control-implementation? (assembly), back-matter? (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>metadata (assembly), import-profile (assembly), system-characteristics (assembly), system-implementation (assembly), control-implementation (assembly), back-matter? (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_import-profile" class="matched-1 same">
+            <summary>
+               <code>import-profile</code>: Import Profile</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>href? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>href? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_system-characteristics" class="matched-1 changed">
+            <summary>
+               <code>system-characteristics</code>: System Characteristics</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>system-id* (field), system-name (field), system-name-short? (field), description (field), prop\* (field), annotation\* (assembly), link\* (field), date-authorized? (field), security-sensitivity-level (field), system-information (assembly), security-impact-level (assembly), status (assembly), *leveraged-authorization*\* (assembly), authorization-boundary (assembly), network-architecture? (assembly), data-flow? (assembly), responsible-party\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>system-id* (field), system-name (field), system-name-short? (field), description (field), prop\* (field), annotation\* (assembly), link\* (field), date-authorized? (field), security-sensitivity-level (field), system-information (assembly), security-impact-level (assembly), status (assembly), authorization-boundary (assembly), network-architecture? (assembly), data-flow? (assembly), responsible-party\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_system-id" class="matched-1 same">
+            <summary>
+               <code>system-id</code>: System Identification</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>identifier-type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>identifier-type? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_system-name" class="matched-1 same">
+            <summary>
+               <code>system-name</code>: System Name (Full)</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_system-name-short" class="matched-1 same">
+            <summary>
+               <code>system-name-short</code>: System Name (Short)</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_security-sensitivity-level" class="matched-1 same">
+            <summary>
+               <code>security-sensitivity-level</code>: Security Sensitivity Level</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_system-information" class="matched-1 same">
+            <summary>
+               <code>system-information</code>: System Information</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), information-type* (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), information-type* (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_information-type" class="matched-1 changed">
+            <summary>
+               <code>information-type</code>: Information Type</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>id? (flag), *name*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description (field), information-type-id\* (field), prop\* (field), confidentiality-impact (assembly), integrity-impact (assembly), availability-impact (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title** (field), description (field), information-type-id\* (field), prop\* (field), confidentiality-impact (assembly), integrity-impact (assembly), availability-impact (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_information-type-id" class="matched-1 same">
+            <summary>
+               <code>information-type-id</code>: Information Type Identifier</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>system? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>system? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_confidentiality-impact" class="matched-1 same">
+            <summary>
+               <code>confidentiality-impact</code>: Confidentiality Impact Level</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_integrity-impact" class="matched-1 same">
+            <summary>
+               <code>integrity-impact</code>: Integrity Impact Level</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_availability-impact" class="matched-1 same">
+            <summary>
+               <code>availability-impact</code>: Availability Impact Level</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>prop\* (field), base (field), selected? (field), adjustment-justification? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_base" class="matched-1 same">
+            <summary>
+               <code>base</code>: Base Level (Confidentiality, Integrity, or Availability)</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_selected" class="matched-1 same">
+            <summary>
+               <code>selected</code>: Selected Level (Confidentiality, Integrity, or Availability)</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_adjustment-justification" class="matched-1 same">
+            <summary>
+               <code>adjustment-justification</code>: Adjustment Justification</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_security-impact-level" class="matched-1 same">
+            <summary>
+               <code>security-impact-level</code>: Security Impact Level</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>security-objective-confidentiality? (field), security-objective-integrity? (field), security-objective-availability? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>security-objective-confidentiality? (field), security-objective-integrity? (field), security-objective-availability? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_security-objective-confidentiality" class="matched-1 same">
+            <summary>
+               <code>security-objective-confidentiality</code>: Security Objective: Confidentiality</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_security-objective-integrity" class="matched-1 same">
+            <summary>
+               <code>security-objective-integrity</code>: Security Objective: Integrity</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_security-objective-availability" class="matched-1 same">
+            <summary>
+               <code>security-objective-availability</code>: Security Objective: Availability</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_status" class="matched-1 same">
+            <summary>
+               <code>status</code>: Status</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>state? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>state? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_leveraged-authorization" class="matched-1 changed">
+            <summary>
+               <code>leveraged-authorization</code>: Leveraged Authorization</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>id? (flag), *name*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), *party-id* (field), date-authorized (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title** (field), prop\* (field), annotation\* (assembly), link\* (field), **party-uuid** (field), date-authorized (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_date-authorized" class="matched-1 same">
+            <summary>
+               <code>date-authorized</code>: System Authorization Date</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_authorization-boundary" class="matched-1 same">
+            <summary>
+               <code>authorization-boundary</code>: Authorization Boundary</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_diagram" class="matched-1 changed">
+            <summary>
+               <code>diagram</code>: Diagram</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description? (field), prop\* (field), link\* (field), caption? (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>description? (field), prop\* (field), link\* (field), caption? (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_caption" class="matched-1 same">
+            <summary>
+               <code>caption</code>: Caption</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_network-architecture" class="matched-1 same">
+            <summary>
+               <code>network-architecture</code>: Network Architecture</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_data-flow" class="matched-1 same">
+            <summary>
+               <code>data-flow</code>: Data Flow</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), diagram\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_system-implementation" class="matched-1 changed">
+            <summary>
+               <code>system-implementation</code>: System Implementation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), user* (assembly), component\* (assembly), *service*\* (assembly), *interconnection*\* (assembly), system-inventory? (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), **leveraged-authorization**\* (assembly), user* (assembly), component\* (assembly), system-inventory? (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_user" class="matched-1 changed">
+            <summary>
+               <code>user</code>: System User Class</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*id*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**uuid**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>title? (field), short-name? (field), description? (field), prop\* (field), annotation\* (assembly), link\* (field), role-id* (field), authorized-privilege\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>title? (field), short-name? (field), description? (field), prop\* (field), annotation\* (assembly), link\* (field), role-id* (field), authorized-privilege\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_role-id" class="matched-1 changed">
+            <summary>
+               <code>role-id</code>: Role Identifier Reference</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_authorized-privilege" class="matched-1 changed">
+            <summary>
+               <code>authorized-privilege</code>: Privilege</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>*name*? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description? (field), function-performed* (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title** (field), description? (field), function-performed* (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_function-performed" class="matched-1 same">
+            <summary>
+               <code>function-performed</code>: Functions Performed</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_component" class="matched-1 changed">
+            <summary>
+               <code>component</code>: Component</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>*id*? (flag), name? (flag), component-type? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>**uuid**? (flag), component-type? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), status (assembly), responsible-role\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title** (field), description (field), **purpose**? (field), prop\* (field), annotation\* (assembly), link\* (field), status (assembly), responsible-role\* (assembly), **protocol**\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_protocol" class="matched-1 changed">
+            <summary>
+               <code>protocol</code>: Protocol</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>name? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>**uuid**? (flag), name? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>port-range\* (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**title**? (field), port-range\* (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_port-range" class="matched-1 same">
+            <summary>
+               <code>port-range</code>: Port Range</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>start? (flag), end? (flag), transport? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>start? (flag), end? (flag), transport? (flag)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_purpose" class="matched-1 same">
+            <summary>
+               <code>purpose</code>: Purpose</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_system-inventory" class="matched-1 same">
+            <summary>
+               <code>system-inventory</code>: System Inventory</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>inventory-item* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>inventory-item* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_inventory-item" class="matched-1 changed">
+            <summary>
+               <code>inventory-item</code>: Inventory Item</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>*id*? (flag), asset-id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>**uuid**? (flag), asset-id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), implemented-component\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), implemented-component\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_implemented-component" class="matched-1 same">
+            <summary>
+               <code>implemented-component</code>: Implemented Component</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>component-id? (flag), use? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>component-id? (flag), use? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), responsible-party\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_control-implementation" class="matched-1 same">
+            <summary>
+               <code>control-implementation</code>: Control Implementation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description (field), implemented-requirement* (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>description (field), implemented-requirement* (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_implemented-requirement" class="matched-1 changed">
+            <summary>
+               <code>implemented-requirement</code>: Control-based Requirement</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flags: </span>*id*? (flag), control-id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>**uuid**? (flag), control-id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description? (field), prop\* (field), annotation\* (assembly), link\* (field), by-component\* (assembly), responsible-role\* (assembly), *set-param*\* (assembly), statement\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>description? (field), prop\* (field), annotation\* (assembly), link\* (field), by-component\* (assembly), responsible-role\* (assembly), **set-parameter**\* (assembly), statement\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_statement" class="matched-1 changed">
+            <summary>
+               <code>statement</code>: Specific Statement</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>statement-id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>statement-id? (flag), **uuid**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description? (field), prop\* (field), link\* (field), responsible-role\* (assembly), by-component\* (assembly), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>description? (field), prop\* (field), **annotation**\* (assembly), link\* (field), responsible-role\* (assembly), by-component\* (assembly), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_responsible-role" class="matched-1 changed">
+            <summary>
+               <code>responsible-role</code>: Responsible Role</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>role-id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>role-id? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>prop\* (field), annotation\* (assembly), link\* (field), *party-id*\* (field), remarks? (field)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>prop\* (field), annotation\* (assembly), link\* (field), **party-uuid**\* (field), remarks? (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_by-component" class="matched-1 changed">
+            <summary>
+               <code>by-component</code>: Component Control Implementation</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span>component-id? (flag)</p>
+                  <p class="now">
+                     <span class="label">\[M3] flags: </span>component-id? (flag), **uuid**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-role\* (assembly), *set-param*\* (assembly)</p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>description (field), prop\* (field), annotation\* (assembly), link\* (field), responsible-role\* (assembly), **set-parameter**\* (assembly)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_set-parameter" class="matched-0 new">
+            <summary>
+               <code>set-parameter</code>: Set Parameter Value</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span>**param-id**? (flag)</p>
+               </div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] model: </span>
+                  </p>
+                  <p class="now">
+                     <span class="label">\[M3] model: </span>**value** (field)</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_value" class="matched-1 same">
+            <summary>
+               <code>value</code>: Value</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+         <details id="assembly_param-id" class="matched-1 same">
+            <summary>
+               <code>param-id</code>: Parameter ID</summary>
+            <div>
+               <div class="comparison">
+                  <p class="was">
+                     <span class="label">\[M2] flag: </span> [none]</p>
+                  <p class="now">
+                     <span class="label">\[M3] flag: </span> [none]</p>
+               </div>
+            </div>
+         </details>
+      </div>
+   </body>
+</html>

--- a/toolchains/xslt-proto-v04/compare/metaschema-analyze.xpl
+++ b/toolchains/xslt-proto-v04/compare/metaschema-analyze.xpl
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+  xmlns:c="http://www.w3.org/ns/xproc-step" version="1.0"
+  xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+  type="m:metaschema-analyze" name="metaschema-analyze">
+  
+  
+  <p:input port="input" primary="true" sequence="false"/>
+  
+  <p:input port="parameters" kind="parameter"/>
+  
+  <p:output port="a.composed" primary="false">
+    <p:pipe port="result" step="compose"/>
+  </p:output>
+  <p:serialization port="a.composed"     indent="true"/>
+  
+  <p:output port="c.analysis" primary="true">
+    <p:pipe port="result" step="analyze"/>
+  </p:output>
+  <p:serialization port="c.analysis"     indent="true"/>
+  
+  <!--<p:output port="markdown" primary="false">
+    <p:pipe port="result" step="Markdown"/>
+  </p:output>-->
+  
+  <!--<p:serialization port="final"        indent="true"  method="xml"
+    doctype-public="-//W3C//DTD XHTML 1.1//EN"
+    doctype-system="http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"
+   />-->
+  <!--<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" 
+   "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">-->
+  
+  
+  <p:xslt name="compose">
+    <p:input port="stylesheet">
+      <p:document href="metaschema-compose.xsl"/>
+    </p:input>
+  </p:xslt>
+  
+  <p:xslt name="analyze" version="3.0">
+    <p:input port="stylesheet">
+      <p:document href="analyze-metaschema.xsl"/>
+    </p:input>
+  </p:xslt>
+
+  <!--
+  <p:xslt name="rendered" version="1.0">
+    <p:input port="stylesheet">
+      <!-\-<p:document href="../XSLT/HTML/oscal-basic-display.xsl"/>-\->
+      <p:document href="../XSLT/oscal-with-nav-display.xsl"/>
+    </p:input>
+  </p:xslt>
+  
+  <!-\- Last chance for comments, PIs etc. -\->
+  <p:xslt name="final">
+    <p:with-param name="xslt-process" select="' OSCAL PROFILE RESOLUTION AND RENDERING pipeline -profile-resolve-and-display.xpl- '"/>
+    <p:input port="stylesheet">
+      <p:document href="../XSLT/html-finalize.xsl"/>
+    </p:input>
+    <!-\-<p:input port="parameters" kind="parameter"/>-\->
+      
+  </p:xslt>-->
+  
+ 
+</p:declare-step>

--- a/toolchains/xslt-proto-v04/compare/metaschema-compare.xpl
+++ b/toolchains/xslt-proto-v04/compare/metaschema-compare.xpl
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+  xmlns:c="http://www.w3.org/ns/xproc-step" version="1.0"
+  xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+  type="m:metaschema-compare" name="metaschema-compare">
+  
+  
+  <p:option name="old.site" select="'https://raw.githubusercontent.com/usnistgov/OSCAL/v1.0.0-milestone2'"/>
+  
+  <p:option name="new.site" select="'https://raw.githubusercontent.com/usnistgov/OSCAL/master'"/>
+  
+  <p:option name="schema.path" select="'/src/metaschema/oscal_catalog_metaschema.xml'"/>
+  
+  <p:option name="old.location" select="$old.site || $schema.path"/>
+  <p:option name="new.location" select="$new.site || $schema.path"/>
+  
+  <p:option name="new.label" select="'Milestone 3 [M3]'"/>
+  <p:option name="old.label" select="'Milestone 2 [M2]'"/>
+  
+  <p:input port="null" primary="true">
+    <p:empty/>
+  </p:input>
+  
+  <p:input port="parameters" kind="parameter"/>
+  
+  <p:output port="a.composed_new" primary="false">
+    <p:pipe port="result" step="new.composed"/>
+  </p:output>
+  <p:serialization port="a.composed_new"     indent="true"/>
+  
+  <p:output port="a.composed_old" primary="false">
+    <p:pipe port="result" step="old.composed"/>
+  </p:output>
+  <p:serialization port="a.composed_old"     indent="true"/>
+  
+  <p:output port="b.grouped" primary="false">
+    <p:pipe port="result" step="grouped"/>
+  </p:output>
+  <p:serialization port="b.grouped"     indent="true"/>
+  
+  <p:output port="c.comparing" primary="true">
+    <p:pipe port="result" step="compared"/>
+  </p:output>
+  <p:serialization port="c.comparing"     indent="true"/>
+  
+  <!--<p:output port="markdown" primary="false">
+    <p:pipe port="result" step="Markdown"/>
+  </p:output>-->
+  
+  <!--<p:serialization port="final"        indent="true"  method="xml"
+    doctype-public="-//W3C//DTD XHTML 1.1//EN"
+    doctype-system="http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"
+   />-->
+  <!--<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" 
+   "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">-->
+  
+  
+  <p:load name="echo.new.metaschema">
+    <p:with-option name="href" select="$new.location"/>
+  </p:load>
+  
+  <p:xslt name="new.composed">
+    <p:input port="stylesheet">
+      <p:document href="metaschema-compose.xsl"/>
+    </p:input>
+  </p:xslt>
+  
+  <p:sink/>
+  
+  <p:load name="echo.old.metaschema">
+    <p:with-option name="href" select="$old.location"/>
+  </p:load>
+  
+  
+  <p:xslt name="old.composed">
+    <p:input port="stylesheet">
+      <p:document href="metaschema-compose.xsl"/>
+    </p:input>
+  </p:xslt>
+  
+  <p:pack name="grouped">
+    <p:input port="source">
+      <p:pipe port="result" step="new.composed"/>
+    </p:input>
+    <p:input port="alternate">
+      <p:pipe port="result" step="old.composed"/>
+    </p:input>
+    <p:with-option name="wrapper" select="xs:QName('m:compare')"/>
+  </p:pack>
+  
+  <p:xslt name="compared" version="3.0">
+    <p:input port="stylesheet">
+      <p:document href="compare-metaschemas.xsl"/>
+    </p:input>
+    <p:with-param name="new-label" select="$new.label"/>
+    <p:with-param name="old-label" select="$old.label"/>
+  </p:xslt>
+
+  <!--
+  <p:xslt name="rendered" version="1.0">
+    <p:input port="stylesheet">
+      <!-\-<p:document href="../XSLT/HTML/oscal-basic-display.xsl"/>-\->
+      <p:document href="../XSLT/oscal-with-nav-display.xsl"/>
+    </p:input>
+  </p:xslt>
+  
+  <!-\- Last chance for comments, PIs etc. -\->
+  <p:xslt name="final">
+    <p:with-param name="xslt-process" select="' OSCAL PROFILE RESOLUTION AND RENDERING pipeline -profile-resolve-and-display.xpl- '"/>
+    <p:input port="stylesheet">
+      <p:document href="../XSLT/html-finalize.xsl"/>
+    </p:input>
+    <!-\-<p:input port="parameters" kind="parameter"/>-\->
+      
+  </p:xslt>-->
+  
+ 
+</p:declare-step>

--- a/toolchains/xslt-proto-v04/compare/metaschema-compare.xpl
+++ b/toolchains/xslt-proto-v04/compare/metaschema-compare.xpl
@@ -9,7 +9,7 @@
   
   <p:option name="new.site" select="'https://raw.githubusercontent.com/usnistgov/OSCAL/master'"/>
   
-  <p:option name="schema.path" select="'/src/metaschema/oscal_catalog_metaschema.xml'"/>
+  <p:option name="schema.path" select="'/src/metaschema/oscal_ssp_metaschema.xml'"/>
   
   <p:option name="old.location" select="$old.site || $schema.path"/>
   <p:option name="new.location" select="$new.site || $schema.path"/>

--- a/toolchains/xslt-proto-v04/compare/metaschema-compose.xsl
+++ b/toolchains/xslt-proto-v04/compare/metaschema-compose.xsl
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xpath-default-namespace="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    exclude-result-prefixes="xs math m xsi"
+    version="3.0">
+    
+<!-- 
+        
+        Not to be used standalone, this XSLT is called by produce-xsd.xsl and produce-json-schema.xsl
+    
+    it depends on declarations for $root-name and for key('definitions-by-name') -->
+    
+    <xsl:output indent="yes"/>
+    
+    <xsl:strip-space elements="METASCHEMA define-flag define-field define-assembly remarks model choice"/>
+    
+    <xsl:variable name="verbose-warnings" as="xs:string">no</xsl:variable>
+    <xsl:variable name="verbose" select="lower-case($verbose-warnings)=('yes','y','1','true')"/>
+    
+    <xsl:variable name="root-name" select="/METASCHEMA/@root/string(.)"/>
+    
+    <xsl:variable name="target-ns" select="/METASCHEMA/namespace/string()"/>
+    
+    <xsl:key name="definition-by-name" match="define-flag | define-field | define-assembly" use="@name"/>
+    
+    <xsl:template match="/">
+        <!--<xsl:sequence select="$compleat"/>-->
+        <!--<xsl:sequence select="$eligible"/>-->
+        <xsl:sequence select="$composed-metaschema"/>
+    </xsl:template>
+    
+<!-- pull all schemas together
+     traverse from top level
+       discard any definition that has a subsequent override
+       definitions to be kept:
+         include docs from <augment> elements
+         annotate with home module
+         expand @group-as on field | flag | assembly ?
+     
+     diagnostic mode
+       notes when definitions are discarded or kept
+         switch $verbose
+       lists analysis of keepers and tossers? by analyzing $compleat
+       alerts when formal-name or description is overridden in imports
+     -->
+
+    
+    <!-- ====== ====== ====== ====== ====== ====== ====== ====== ====== ====== ====== ====== -->
+    <!-- Pass One: assemble definitions -->
+    
+    <xsl:variable name="compleat" as="document-node()">
+        <xsl:apply-templates mode="acquire" select="/">
+            <xsl:with-param name="so-far" tunnel="true" select="document-uri(/)"/>
+        </xsl:apply-templates>
+    </xsl:variable>
+
+    <xsl:mode name="acquire" on-no-match="shallow-copy"/>
+    
+    <xsl:template match="comment() | processing-instruction()" mode="acquire"/>
+    
+    <xsl:template match="METASCHEMA" mode="acquire">
+        <xsl:copy copy-namespaces="no">
+            <xsl:copy-of select="@* except @xsi:*"/>
+            <xsl:attribute name="module" select="document-uri(/)"/>
+            <xsl:apply-templates mode="#current"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    
+    <!-- quitting traversal by cloning branch -->
+    <xsl:template match="define-field | define-flag | define-assembly" mode="acquire">
+        <xsl:copy-of select="."/>
+    </xsl:template>
+    
+    <xsl:template match="import" mode="acquire">
+        <xsl:param name="so-far" tunnel="yes" required="yes"/>
+        <xsl:variable name="uri" select="resolve-uri(@href,document-uri(/))"/>
+        <xsl:choose>
+            <xsl:when test="$uri = $so-far">
+                <xsl:comment expand-text="true">Warning: circular import of { $uri } skipped</xsl:comment>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:apply-templates select="document($uri)/METASCHEMA" mode="acquire">
+                    <xsl:with-param name="so-far" select="$so-far,$uri"/>
+                </xsl:apply-templates>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    
+    <!-- ====== ====== ====== ====== ====== ====== ====== ====== ====== ====== ====== ====== -->
+    <!-- Pass Two: filter definitions (1) - eligible definitions are the last-declared with their name
+         but we keep everything else including all 'augments' (documentation) for the next pass -->
+    <xsl:variable name="eligible" as="document-node()">
+        <xsl:apply-templates select="$compleat" mode="keep-eligible"/>
+    </xsl:variable>
+
+    <xsl:mode name="keep-eligible" on-no-match="shallow-copy"/>
+    
+    <xsl:template mode="keep-eligible" priority="10"
+        match="define-field[   . is key('definition-by-name',@name)[last()]]
+             | define-flag[    . is key('definition-by-name',@name)[last()]] 
+             | define-assembly[. is key('definition-by-name',@name)[last()]]">
+        <xsl:if test="$verbose">
+            <xsl:message expand-text="true">KEEPING definition for '{ @name }' { replace(local-name(),'^define-','')} from { ancestor::METASCHEMA[1]/@module }</xsl:message>
+        </xsl:if>
+        <xsl:copy-of select="."/>
+    </xsl:template>
+
+    <!-- Tossing definitions we aren't keeping -->
+    <xsl:template mode="keep-eligible"
+        match="define-field | define-flag | define-assembly">
+        <xsl:if test="$verbose">
+            <xsl:message expand-text="true">TOSSING definition for '{ @name }' { replace(local-name(),'^define-','')}  from { ancestor::METASCHEMA[1]/@module }</xsl:message>
+        </xsl:if>
+    </xsl:template>
+        
+    <!-- ====== ====== ====== ====== ====== ====== ====== ====== ====== ====== ====== ====== -->
+    <!-- Pass Three: filter definitions (1) - keep definitions actually used, with all docs
+          (i.e. drops definitions 'never picked for a team') -->
+    <!-- Also consolidates documentation - definitions that are kept, are also annotated
+           with applicable 'augment' elements i.e. those belonging to ancestor metaschemas
+           in the import hierarchy. -->
+    
+    <xsl:variable name="composed-metaschema" as="document-node()">
+        <xsl:variable name="all-references" as="xs:string*">
+            <xsl:apply-templates mode="collect-references" select="$eligible/METASCHEMA/*[@name=$root-name]">
+                <xsl:with-param tunnel="yes" name="ref-stack" select="()"/>
+            </xsl:apply-templates>
+        </xsl:variable>
+        <xsl:apply-templates select="$eligible" mode="digest">
+            <xsl:with-param tunnel="yes" name="keepers" select="$all-references"/>
+        </xsl:apply-templates>
+    </xsl:variable>
+    
+    <xsl:mode name="digest" on-no-match="shallow-copy"/>
+    
+    <xsl:template match="METASCHEMA//METASCHEMA" priority="5" mode="digest">
+        <xsl:apply-templates mode="#current"/>
+    </xsl:template>
+    
+    <xsl:template match="formal-name//text() | description//text() | p//text()" mode="digest">
+        <xsl:value-of select="replace(.,'\s+',' ')"/>
+    </xsl:template>
+    
+    <!-- Dropping augment elements since their contents are being consolidated. -->
+    <xsl:template match="augment" mode="digest"/>
+
+    <!-- Dropping metaschema superstructure from sub modules -->
+    <xsl:template match="METASCHEMA//METASCHEMA/*" mode="digest"/>
+
+    <xsl:template priority="10" match="define-assembly | define-field | define-flag" mode="digest">
+        <xsl:param name="keepers" tunnel="yes" required="yes"/>
+        <xsl:variable name="my-name" select="@name"/>
+        <xsl:variable name="me-and-mine" select="ancestor::METASCHEMA/augment[@name=$my-name] | ."/>
+        <xsl:if test="@name = $keepers">
+            <xsl:copy>
+                <xsl:call-template name="mark-module"/>
+                <xsl:copy-of select="@*"/>
+                <xsl:copy-of select="$me-and-mine[last()]/formal-name"/>
+                <xsl:if test="$verbose and ($me-and-mine/formal-name != $me-and-mine/formal-name)">
+                    <xsl:message expand-text="true">Formal name override for  { replace(local-name(),'^define-','')} '{ @name }': using "{ $me-and-mine[last()]/formal-name }"</xsl:message>
+                </xsl:if>
+                <xsl:copy-of select="$me-and-mine[last()]/description"/>
+                <xsl:apply-templates mode="#current" select="json-key, json-value-key, flag"/>
+                <xsl:copy-of select="$me-and-mine[last()]/allowed-values"/>
+                <xsl:copy-of select="model"/>
+                <xsl:apply-templates mode="#current" select="$me-and-mine/remarks">
+                    <xsl:sort select="position()" order="descending"/><!-- reversing the order -->
+                </xsl:apply-templates>
+                <xsl:apply-templates mode="#current" select="$me-and-mine/example">
+                    <xsl:sort select="position()" order="descending"/><!-- reversing the order -->
+                </xsl:apply-templates>
+            </xsl:copy>
+        </xsl:if>
+        <xsl:if test="$verbose and not(@name = $keepers)">
+            <xsl:message expand-text="true">DISCARDING definition for '{ @name }' { replace(local-name(),'^define-','')} from { ancestor::METASCHEMA[1]/@module } (not being used)</xsl:message>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template mode="digest" match="augment/remarks | augment/example">
+        <xsl:copy>
+            <xsl:call-template name="mark-module"/>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates mode="#current"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template priority="10" mode="digest" match="example/description | example/remarks">
+        <xsl:copy-of select="."/>
+    </xsl:template>
+    
+    <!-- Casting all examples into the master metaschema's declared namespace. -->
+    <xsl:template mode="digest" match="example//* | example//*">
+        <xsl:element name="{ local-name() }" namespace="{ $target-ns }">
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates mode="#current"/>
+        </xsl:element>
+    </xsl:template>
+    
+    <xsl:template mode="digest" match="flag | json-key | json-value-key">
+        <xsl:copy>
+            <xsl:copy-of select="key('definition-by-name',(@name|@ref))/@as-type"/>
+            <!-- Allowing local datatype to override the definition's datatype -->
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates mode="#current"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template name="mark-module">
+        <xsl:copy-of select="ancestor-or-self::METASCHEMA/@module"/>
+    </xsl:template>
+    
+<!-- Mode 'collect references' collects a set of strings naming definitions
+     we actually need, by traversing the definitions tree from the root;
+     recursive models are accounted for -->
+    <xsl:template match="define-assembly" mode="collect-references">
+        <xsl:param name="ref-stack" tunnel="yes" required="yes"/>
+        <xsl:if test="not(@name = $ref-stack)">
+            <xsl:sequence select="@name, flag/@ref"/>
+            <xsl:apply-templates select="model" mode="#current">
+                <xsl:with-param tunnel="true" name="ref-stack" select="$ref-stack,@name"/>
+            </xsl:apply-templates>
+        </xsl:if>
+    </xsl:template>
+    
+    <xsl:template match="define-field" mode="collect-references">
+        <xsl:sequence select="@name, flag/@ref"/>
+    </xsl:template>
+    
+    <xsl:template match="model | model//*" mode="collect-references">
+        <xsl:apply-templates mode="#current"/>  
+    </xsl:template>
+    
+    <!-- Matching inside the $distinct-definitions variable, so traversing only applicable definitions -->
+    <xsl:template priority="10" match="field | assembly" mode="collect-references">
+        <xsl:apply-templates select="key('definition-by-name',@ref,root())" mode="#current"/>
+    </xsl:template>
+        
+    <!--hitting anything but a define-assembly, we are done collecting references-->
+    <xsl:template match="* | text()" mode="collect-references"/>
+    
+</xsl:stylesheet>

--- a/toolchains/xslt-proto-v04/compare/readme.md
+++ b/toolchains/xslt-proto-v04/compare/readme.md
@@ -1,0 +1,10 @@
+# Metaschema comparison logic
+
+The XProc 1.0 pipeline and supporting XSLTs provide the capability of comparing two metaschemas. The metaschemas to be compared can be hard-wired in the XProc or provided as a runtime option.
+
+A metaschema is "composed" before comparison. The composition logic has not been updated to next-generation Metaschema yet (at time of writing).
+The results are HTML decorated with markdown, so for pasting into a plain text environment. However, an HTML-to-plaintext filter could be added to produce better clean plain text.
+
+HTML files in this directory are examples of the tool in application, as applied to OSCAL metaschemas.
+
+

--- a/toolchains/xslt-proto-v04/compare/schema-metrics.md
+++ b/toolchains/xslt-proto-v04/compare/schema-metrics.md
@@ -1,0 +1,103 @@
+# Schema metrics
+
+Works over a grammar as given in a formal schema (XSD, RNG, DTD)
+
+Or on an 'implicit schema' derived to reflect data object (element/attribute) occurrence across a given data set (one or more documents)
+
+
+Step one - make model tree
+  represents node occurrence
+  at leaves, shows
+    path (back) to data
+    average/mean/mode length
+    some kind of frequency/distribution indicator?
+
+Step two - count parent/child (immediate hierarchical) pairs
+
+c is the number of distinct nodes (elements)
+p is the number of distinct parents
+
+note the parents/children are not distributed evenly
+
+for each c there is a different number of p
+average p for each c? if close to c, then the arbitrariness / containment is high. (high entropy.) if closer to 1, then containment is strict (low entropy).
+
+high entropy: count p/c is close to (c*c) 
+
+      
+      
+```
+<a b="n">
+          <a b="n">
+              <b>
+                  <a>
+                      <b></b>
+                  </a>
+              </b>
+          </a>
+      </a>
+```
+
+A low entropy count p/c is close to count c, p/c^2 is low depending on c (no of children)
+
+```
+<bob>
+        <jim>
+            <jane>
+                <bill></bill>
+                <joe></joe>
+            </jane>
+        </jim>
+        <mark>
+            <mary></mary>
+        </mark>
+    </bob>
+```
+
+
+
+absolute count of object types (element|attribute names)
+
+where { p/c } is a set of p/c instances
+  - extant parent/child
+  - or permissible via schema
+  - count(p) / count(c)*count(c)
+    
+    larger schemas address greater semantic complexity
+    but do not always provide advantages
+    paradoxically they can be difficult to extend and adapt
+    also, problem of 'many ways to do things' is not solved
+      by having more ways to do things
+    
+    for every a/b pair, how many have a b/a pair?
+    how many a permit a//a?
+    
+## Semantic ordering
+
+Such as, paragraph ordering within a section or block
+
+how many element types exhibit possible semantic ordering among their children (or siblings)?
+
+
+e has semantic order if it contains some E such that
+a sibling has a different name with a sibling named E
+
+(following-sibling::* except following-sibling::E)/following-sibling::E
+
+or group-adjacent by E and see if two groups have the same grouping key
+
+SCHEMA
+  element type count
+  
+  parent/child analysis
+    entropy metric (more 'entropy' = more generic modeling)
+
+SURVEY OF ELEMENTS
+  list - distinct parent types
+         distinct child types
+         proportion exhibiting semantic ordering among children
+         
+         
+      (exists preceding sibling of a different name following a preceding sibling of the same name)
+      
+Mixed content as a species of semantic ordering


### PR DESCRIPTION
# Committer Notes

A new subdirectory within the `xslt-04` implementation provides a first version of a metaschema comparison capability (developed for the OSCAL Milestone 3 delivery)

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? **working on the readme**
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)? **to be discussed**
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
