### PR TITLE
Repairing markdown production bug

### DIFF
--- a/toolchains/oscal-m2/xml/produce-xml-converter.xsl
+++ b/toolchains/oscal-m2/xml/produce-xml-converter.xsl
@@ -529,12 +529,12 @@
 
         <XSLT:template mode="md" priority="1" match="ul | ol">
             <XSLT:call-template name="conditional-lf"/>
-            <XSLT:apply-templates select="* mode="md"/>
+            <XSLT:apply-templates select="*" mode="md"/>
             <string/>
         </XSLT:template>
 
         <XSLT:template mode="md" match="ul//ul | ol//ol | ol//ul | ul//ol">
-            <XSLT:apply-templates select="* mode="md"/>
+            <XSLT:apply-templates select="*" mode="md"/>
         </XSLT:template>
 
         <XSLT:template mode="md" match="li">

--- a/toolchains/oscal-m2/xml/produce-xml-converter.xsl
+++ b/toolchains/oscal-m2/xml/produce-xml-converter.xsl
@@ -529,18 +529,18 @@
 
         <XSLT:template mode="md" priority="1" match="ul | ol">
             <XSLT:call-template name="conditional-lf"/>
-            <XSLT:apply-templates mode="md"/>
+            <XSLT:apply-templates select="* mode="md"/>
             <string/>
         </XSLT:template>
 
         <XSLT:template mode="md" match="ul//ul | ol//ol | ol//ul | ul//ol">
-            <XSLT:apply-templates mode="md"/>
+            <XSLT:apply-templates select="* mode="md"/>
         </XSLT:template>
 
         <XSLT:template mode="md" match="li">
             <string>
                 <XSLT:for-each select="../ancestor::ul">
-                    <XSLT:text>&#32;&#32;</XSLT:text>
+                    <XSLT:text xml:space="preserve">&#32;&#32;</XSLT:text>
                 </XSLT:for-each>
                 <XSLT:text>* </XSLT:text>
                 <XSLT:apply-templates mode="md"/>
@@ -552,7 +552,7 @@
             <string/>
             <string>
                 <XSLT:for-each select="../ancestor::ul">
-                    <XSLT:text>&#32;&#32;</XSLT:text>
+                    <XSLT:text xml:space="preserve">&#32;&#32;</XSLT:text>
                 </XSLT:for-each>
                 <XSLT:text>1. </XSLT:text>
                 <XSLT:apply-templates mode="md"/>


### PR DESCRIPTION
# Committer Notes

Addresses usnistgov/OSCAL#701 - glitch in Markdown production when markup-multiline includes `ul` or `ol`. Whitespace was leaking in and throwing things off; fortunately a runtime data type check failed. Now the whitespace won't be let through.

Also preemptively repaird a bug that would throw off list nesting.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? **see usnistgov/OSCAL#701**
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
