### PR TITLE
Refactoring of Schematron and JSON validation support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,3 +3,7 @@
 	url = git@github.com:usnistgov/hugo-uswds.git
 	branch = master
 	update = rebase
+[submodule "support/schematron"]
+	path = support/schematron
+	url = git@github.com:usnistgov/schematron.git
+	branch = master

--- a/scripts/include/init-schematron.sh
+++ b/scripts/include/init-schematron.sh
@@ -5,7 +5,8 @@ init_schematron() {
   source "${my_dir}/init-saxon.sh"
 
   if [[ -z "$SCHEMATRON_HOME" ]]; then
-      echo -e "${P_ERROR}SCHEMATRON_HOME is not set or is empty.${P_END} ${P_INFO}Please set SCHEMATRON_HOME to indicate the location of the schematron skeleton. The schematron skeleton can be cloned using git clone https://github.com/Schematron/schematron <schematron_home_dir>.${P_END}"
+    echo -e "${P_INFO}SCHEMATRON_HOME is not set or is empty.${P_END} ${P_INFO}Please set SCHEMATRON_HOME to indicate the location of the schematron skeleton. The schematron skeleton can be cloned using git clone https://github.com/Schematron/schematron <schematron_home_dir>.${P_END}"
+    SCHEMATRON_HOME="${my_dir}/../../support/schematron"
   fi
 
   SCHEMATRON_DIR="$SCHEMATRON_HOME/trunk/schematron/code"

--- a/scripts/include/init-validate-content.sh
+++ b/scripts/include/init-validate-content.sh
@@ -7,26 +7,26 @@ init_validation() {
   if [ -z ${METASCHEMA_SCRIPT_INIT+x} ]; then
     source "${my_dir}/common-environment.sh"
   fi
-  source "${my_dir}/init-saxon.sh"
+#  source "${my_dir}/init-saxon.sh"
 }
 
-check_json_cli() {
-  if [[ -z "$JSON_CLI_HOME" ]]; then
-      if [[ -z "$JSON_CLI_VERSION" ]]; then
-          echo -e "${P_ERROR}JSON_CLI_VERSION is not set or is empty.${P_END} ${P_INFO}Please set JSON_CLI_VERSION to indicate the library version${P_END}"
-      fi
-      JSON_CLI_HOME=~/.m2/repository/gov/nist/oscal/json-cli/${JSON_CLI_VERSION}
-  fi
-}
+#check_json_cli() {
+#  if [[ -z "$JSON_CLI_HOME" ]]; then
+#      if [[ -z "$JSON_CLI_VERSION" ]]; then
+#          echo -e "${P_ERROR}JSON_CLI_VERSION is not set or is empty.${P_END} ${P_INFO}Please set JSON_CLI_VERSION to indicate the library version${P_END}"
+#      fi
+#      JSON_CLI_HOME=~/.m2/repository/gov/nist/oscal/json-cli/${JSON_CLI_VERSION}
+#  fi
+#}
 
 validate_json() {
-  check_json_cli
+#  check_json_cli
 
   local schema_file="$1"; shift
   local instance_file="$1"; shift
   local extra_params=($@)
 
-  local classpath=$(JARS=("$JSON_CLI_HOME"/*.jar); IFS=:; echo -e "${JARS[*]}")
+#  local classpath=$(JARS=("$JSON_CLI_HOME"/*.jar); IFS=:; echo -e "${JARS[*]}")
 
   set --
 
@@ -39,14 +39,15 @@ validate_json() {
   if [ -z "$instance_file" ]; then
       echo -e "${P_ERROR}The JSON file must be provided as the second argument.${P_END}"
   else
-    set -- "$@" "-v" "${instance_file}"
+#    set -- "$@" "-v" "${instance_file}"
+    set -- "$@" "-d" "${instance_file}"
   fi
 
-  java -cp "$classpath" gov.nist.oscal.json.JsonCLI "$@" "${extra_params[@]}"
+  ajv "$@" "${extra_params[@]}"
   exitcode=$?
   if [ "$exitcode" -ne 0 ]; then
       if [ "$exitcode" -gt 1 ]; then
-          echo -e "${P_ERROR}Error running JsonCLI.${P_END}"
+          echo -e "${P_ERROR}Error running ajv.${P_END}"
       else
           echo -e "${instance_file} is invalid."
       fi


### PR DESCRIPTION

# Committer Notes

Added Schematron skeleton repo as a submodule. This will allow the version of the skeleton used to be better controlled.

Changed JSON validator from the [custom Java implementation](https://github.com/usnistgov/oscal-tools/tree/master/json-cli) to to use of [ajv](https://github.com/ajv-validator/ajv-cli). This simplifies the CI/CD workflow as the json-cli doesn't need to be built anymore.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
