### PR TITLE
removed extra type property within generated JSON allof statements

### DIFF
--- a/toolchains/oscal-m2/json/json-schema-metamap.xsl
+++ b/toolchains/oscal-m2/json/json-schema-metamap.xsl
@@ -371,8 +371,8 @@
             <map key="additionalProperties">
                 <array key="allOf">
                     <map>
-                <string key="type">object</string>
-                <string key="$ref">#/definitions/{ @ref }</string>
+<!--                <string key="type">object</string>
+-->                <string key="$ref">#/definitions/{ @ref }</string>
                     </map>
                     <map>
                         <map key="not">


### PR DESCRIPTION
# Committer Notes

Removed extra `"type": "object"` property within generated JSON allof statements.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
