### PR TITLE
Updating submodules to use HTTP instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "website/themes/uswds"]
 	path = website/themes/uswds
-	url = git@github.com:usnistgov/hugo-uswds.git
+	url = https://github.com/usnistgov/hugo-uswds.git
 	branch = master
 	update = rebase
 [submodule "support/schematron"]
 	path = support/schematron
-	url = git@github.com:usnistgov/schematron.git
+	url = https://github.com/usnistgov/schematron.git
 	branch = master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,3 +91,39 @@ This project is in the public domain within the United States, and copyright and
 ## Contributions will be released into the public domain
 
 All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+
+## Git Client Setup
+
+### Initializing Git submodules
+
+This GitHub repository makes use of Git submodules to mount other repositories as subdirectories.
+
+When cloning this repo for the first time, you need to initialize the submodules that this repository depends on. To do this you must execute the following command:
+
+```
+git submodule update --init
+```
+
+You can perform the clone and submodule initialization in a single step by using the following command:
+
+```
+git clone --recurse-submodules https://github.com/usnistgov/metaschema.git
+```
+
+### Configuring Submodules to Use SSH
+
+Some clients will make use of Git over SSH with a private SSH key for GitHub projects. For convenience, the submodules are configured to use HTTP instead of SSH. To override this default behavior, you will need to configure your Git client to use SSH instead of HTTP using the following command:
+
+```
+git config --global url."git@github.com:".insteadOf https://github.com/
+```
+
+This instructs your Git client to dynamically replace the HTTP-based URLs with the proper SSH URL when using GitHub.
+
+### Updating submodules
+
+Submodule contents will be periodically updated. To ensure you have the latest commits for a configured submodule, you will need to run the following command:
+
+```
+git submodule update --init --recursive
+```


### PR DESCRIPTION
# Committer Notes

Fixing submodule URLs to use HTTP by default per usnistgov/OSCAL#753.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
