### PR TITLE
Repair to Metaschema Schematron checking for name clashes among siblings

### DIFF
--- a/toolchains/xslt-M4/validate/metaschema-check.sch
+++ b/toolchains/xslt-M4/validate/metaschema-check.sch
@@ -58,7 +58,7 @@
             <sch:let name="def" value="nm:definition-for-reference(.)"/>
             <sch:assert test="exists($def) or $metaschema-is-abstract">No definition is given for <sch:name/> '<sch:value-of select="@ref"/>'.</sch:assert>
             <sch:assert test="exists($aka) or empty($def)"><sch:name/> has no name defined</sch:assert>
-            <sch:let name="siblings" value="(../m:flag | ../m:define-flag | ancestor::m:model//m:field | ancestor::m:model//m:assembly | ancestor::m:model//define-field | ancestor::m:model//m:define-assembly) except ."/>
+            <sch:let name="siblings" value="(../m:flag | ../m:define-flag | ancestor::m:model[1]/(.|m:choice)/m:field | ancestor::m:model[1]/(.|m:choice)/m:assembly | ancestor::m:model/(.|m:choice)/define-field | ancestor::m:model[1]/(.|m:choice)/m:define-assembly) except ."/>
             <sch:let name="rivals" value="$siblings[nm:identifiers(.) = $aka]"/>
             <sch:assert test="empty($rivals)">Name clash on <sch:name/> using name '<sch:value-of select="$aka"/>'; clashes with neighboring <xsl:value-of select="$rivals/local-name()" separator=", "/></sch:assert>
         </sch:rule>


### PR DESCRIPTION
# Committer Notes

Repair to Metaschema Schematron checking for name clashes among siblings.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x Have you added an explanation of what your changes do and why you'd like us to include them?
- [x Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
