### PR TITLE
Corrects schema generation bug when definitions with scope='local' are chained

### DIFF
--- a/test-suite/schema-generation/local-declarations/global-and-scoped-local_generated-json-schema.json
+++ b/test-suite/schema-generation/local-declarations/global-and-scoped-local_generated-json-schema.json
@@ -1,0 +1,70 @@
+
+  { "$schema" : "http://json-schema.org/draft-07/schema#",
+    "$id" : "http://csrc.nist.gov/ns/metaschema/unit-test/group-as-singleton-or-array-optional-schema.json",
+    "$comment" : "Metaschema Unit Test: group-as: JSON Schema",
+    "type" : "object",
+    "definitions" : 
+    { "parent" : 
+      { "title" : "parent",
+        "description" : "parent assembly",
+        "$id" : "#/definitions/parent",
+        "type" : "object",
+        "properties" : 
+        { "local-flag" : 
+          { "title" : "Flag defined locally",
+            "description" : "Has a local definition",
+            "type" : "string" },
+          "global-flag" : 
+          { "title" : "Flag defined globally",
+            "description" : "Has a global definition",
+            "type" : "string" },
+          "global-field" : 
+          { "$ref" : "#/definitions/global-field" },
+          "top-level-local-field" : 
+          { "title" : "Field defined with scope='local', at top level",
+            "description" : "Should result in a local definition",
+            "$id" : "#/definitions/top-level-local-field",
+            "type" : "string" },
+          "top-level-local-assembly" : 
+          { "title" : "Assembly defined with scope='local', at top level",
+            "description" : "Should result as local",
+            "$id" : "#/definitions/top-level-local-assembly",
+            "type" : "object",
+            "properties" : 
+            { "top-level-local-field" : 
+              { "title" : "Field defined with scope='local', at top level",
+                "description" : "Should result in a local definition",
+                "$id" : "#/definitions/top-level-local-field",
+                "type" : "string" },
+              "global-field" : 
+              { "$ref" : "#/definitions/global-field" } },
+            "additionalProperties" : false },
+          "global-assembly" : 
+          { "$ref" : "#/definitions/global-assembly" } },
+        "additionalProperties" : false },
+      "global-field" : 
+      { "title" : "Field defined globally",
+        "description" : "Has a global definition",
+        "$id" : "#/definitions/global-field",
+        "type" : "string" },
+      "global-assembly" : 
+      { "title" : "Assembly defined globally",
+        "description" : "Has a global definition",
+        "$id" : "#/definitions/global-assembly",
+        "type" : "object",
+        "properties" : 
+        { "local-field2" : 
+          { "title" : "Field defined locally",
+            "description" : "Has a local definition",
+            "$id" : "#/definitions/local-field2",
+            "type" : "string" },
+          "global-field" : 
+          { "$ref" : "#/definitions/global-field" } },
+        "additionalProperties" : false } },
+    "properties" : 
+    { "parent" : 
+      { "$ref" : "#/definitions/parent" } },
+    "required" : 
+    [ "parent" ],
+    "additionalProperties" : false,
+    "maxProperties" : 1 }

--- a/test-suite/schema-generation/local-declarations/global-and-scoped-local_generated-xml-schema.xsd
+++ b/test-suite/schema-generation/local-declarations/global-and-scoped-local_generated-xml-schema.xsd
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+           xmlns:metaschema-group-as="http://csrc.nist.gov/ns/metaschema/unit-test/group-as-singleton-or-array-optional"
+           xmlns:oscal-prose="http://csrc.nist.gov/ns/metaschema/unit-test/group-as-singleton-or-array-optional"
+           elementFormDefault="qualified"
+           targetNamespace="http://csrc.nist.gov/ns/metaschema/unit-test/group-as-singleton-or-array-optional"
+           version="1.0-milestone1">
+   <xs:annotation>
+      <xs:appinfo>
+         <m:schema-name>Metaschema Unit Test: group-as</m:schema-name>
+         <m:schema-version>1.0-milestone1</m:schema-version>
+         <m:short-name>metaschema-group-as</m:short-name>
+         <m:root>parent</m:root>
+      </xs:appinfo>
+   </xs:annotation>
+   <xs:element name="parent" type="metaschema-group-as:parent-ASSEMBLY"/>
+   <xs:complexType name="parent-ASSEMBLY">
+      <xs:annotation>
+         <xs:appinfo>
+            <m:formal-name>parent</m:formal-name>
+            <m:description>parent assembly</m:description>
+         </xs:appinfo>
+         <xs:documentation>
+            <b>parent</b>: parent assembly</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="global-field"
+                     type="metaschema-group-as:global-field-FIELD"
+                     minOccurs="0"
+                     maxOccurs="1"/>
+         <xs:element name="top-level-local-field" minOccurs="0" maxOccurs="1">
+            <xs:complexType>
+               <xs:annotation>
+                  <xs:appinfo>
+                     <m:formal-name>Field defined with scope='local', at top level</m:formal-name>
+                     <m:description>Should result in a local definition</m:description>
+                  </xs:appinfo>
+                  <xs:documentation>
+                     <b>Field defined with scope='local', at top level</b>: Should result in a local definition</xs:documentation>
+               </xs:annotation>
+               <xs:simpleContent>
+                  <xs:extension base="xs:string"/>
+               </xs:simpleContent>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="top-level-local-assembly" minOccurs="0" maxOccurs="1">
+            <xs:complexType>
+               <xs:annotation>
+                  <xs:appinfo>
+                     <m:formal-name>Assembly defined with scope='local', at top level</m:formal-name>
+                     <m:description>Should result as local</m:description>
+                  </xs:appinfo>
+                  <xs:documentation>
+                     <b>Assembly defined with scope='local', at top level</b>: Should result as local</xs:documentation>
+               </xs:annotation>
+               <xs:sequence>
+                  <xs:element name="top-level-local-field" minOccurs="0" maxOccurs="1">
+                     <xs:complexType>
+                        <xs:annotation>
+                           <xs:appinfo>
+                              <m:formal-name>Field defined with scope='local', at top level</m:formal-name>
+                              <m:description>Should result in a local definition</m:description>
+                           </xs:appinfo>
+                           <xs:documentation>
+                              <b>Field defined with scope='local', at top level</b>: Should result in a local definition</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleContent>
+                           <xs:extension base="xs:string"/>
+                        </xs:simpleContent>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="global-field"
+                              type="metaschema-group-as:global-field-FIELD"
+                              minOccurs="0"
+                              maxOccurs="1"/>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="global-assembly"
+                     type="metaschema-group-as:global-assembly-ASSEMBLY"
+                     minOccurs="0"
+                     maxOccurs="1"/>
+      </xs:sequence>
+      <xs:attribute name="local-flag" type="xs:string">
+         <xs:annotation>
+            <xs:appinfo>
+               <m:formal-name>Flag defined locally</m:formal-name>
+               <m:description>Has a local definition</m:description>
+            </xs:appinfo>
+            <xs:documentation>
+               <b>Flag defined locally</b>: Has a local definition</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="global-flag" type="xs:string">
+         <xs:annotation>
+            <xs:appinfo>
+               <m:formal-name>Flag defined globally</m:formal-name>
+               <m:description>Has a global definition</m:description>
+            </xs:appinfo>
+            <xs:documentation>
+               <b>Flag defined globally</b>: Has a global definition</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="global-field-FIELD">
+      <xs:annotation>
+         <xs:appinfo>
+            <m:formal-name>Field defined globally</m:formal-name>
+            <m:description>Has a global definition</m:description>
+         </xs:appinfo>
+         <xs:documentation>
+            <b>Field defined globally</b>: Has a global definition</xs:documentation>
+      </xs:annotation>
+      <xs:simpleContent>
+         <xs:extension base="xs:string"/>
+      </xs:simpleContent>
+   </xs:complexType>
+   <xs:complexType name="global-assembly-ASSEMBLY">
+      <xs:annotation>
+         <xs:appinfo>
+            <m:formal-name>Assembly defined globally</m:formal-name>
+            <m:description>Has a global definition</m:description>
+         </xs:appinfo>
+         <xs:documentation>
+            <b>Assembly defined globally</b>: Has a global definition</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="local-field2" minOccurs="0" maxOccurs="1">
+            <xs:complexType>
+               <xs:annotation>
+                  <xs:appinfo>
+                     <m:formal-name>Field defined locally</m:formal-name>
+                     <m:description>Has a local definition</m:description>
+                  </xs:appinfo>
+                  <xs:documentation>
+                     <b>Field defined locally</b>: Has a local definition</xs:documentation>
+               </xs:annotation>
+               <xs:simpleContent>
+                  <xs:extension base="xs:string"/>
+               </xs:simpleContent>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="global-field"
+                     type="metaschema-group-as:global-field-FIELD"
+                     minOccurs="0"
+                     maxOccurs="1"/>
+      </xs:sequence>
+   </xs:complexType>
+</xs:schema>

--- a/test-suite/schema-generation/local-declarations/global-and-scoped-local_metaschema.xml
+++ b/test-suite/schema-generation/local-declarations/global-and-scoped-local_metaschema.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../toolchains/xslt-M4/validate/metaschema-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- OSCAL CATALOG METASCHEMA -->
+<!-- validate with XSD and Schematron (linked) -->
+<METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+            xsi:schemaLocation="../../../toolchains/xslt-M4/validate/metaschema.xsd">
+   <schema-name>Metaschema Unit Test: group-as</schema-name>
+   <schema-version>1.0-milestone1</schema-version>
+   <short-name>metaschema-group-as</short-name>
+   <namespace>http://csrc.nist.gov/ns/metaschema/unit-test/group-as-singleton-or-array-optional</namespace>
+   <define-assembly name="parent">
+      <formal-name>parent</formal-name>
+      <description>parent assembly</description>
+      <root-name>parent</root-name>
+      <define-flag name="local-flag" as-type="string">
+         <formal-name>Flag defined locally</formal-name>
+         <description>Has a local definition</description>
+      </define-flag>
+      <flag ref="global-flag"/>
+      <model>
+         <field    ref="global-field"/>
+         <field    ref="top-level-local-field"/>
+         <assembly ref="top-level-local-assembly"/>
+         <assembly ref="global-assembly"/>
+      </model>
+   </define-assembly>
+   <define-field name="top-level-local-field" as-type="string" scope="local">
+      <formal-name>Field defined with scope='local', at top level</formal-name>
+      <description>Should result in a local definition</description>
+   </define-field>
+   <define-assembly name="top-level-local-assembly" scope="local">
+      <formal-name>Assembly defined with scope='local', at top level</formal-name>
+      <description>Should result as local</description>
+      <model>
+         <field ref="top-level-local-field"/>
+         <field ref="global-field"/>
+      </model>
+   </define-assembly>   
+   <define-flag name="global-flag" as-type="string">
+      <formal-name>Flag defined globally</formal-name>
+      <description>Has a global definition</description>
+   </define-flag>
+   <define-field name="global-field" as-type="string">
+      <formal-name>Field defined globally</formal-name>
+      <description>Has a global definition</description>
+   </define-field>
+   <define-assembly name="global-assembly">
+      <formal-name>Assembly defined globally</formal-name>
+      <description>Has a global definition</description>
+      <model>
+         <define-field name="local-field2" as-type="string">
+            <formal-name>Field defined locally</formal-name>
+            <description>Has a local definition</description>
+         </define-field>
+         <field ref="global-field"/>
+      </model>
+   </define-assembly>
+</METASCHEMA>

--- a/toolchains/xslt-M4/compose/metaschema-collect.xsl
+++ b/toolchains/xslt-M4/compose/metaschema-collect.xsl
@@ -67,15 +67,22 @@
         match="METASCHEMA/define-flag[@scope='local']" use="@name"/>
     
     <xsl:template mode="acquire" match="assembly[exists( key('top-level-local-assembly-definition-by-name',@ref) )]">
-        <xsl:copy-of select="key('top-level-local-assembly-definition-by-name',@ref) "/>
+        <xsl:apply-templates mode="expand" select="key('top-level-local-assembly-definition-by-name',@ref) "/>
     </xsl:template>
     
     <xsl:template mode="acquire" match="field[exists( key('top-level-local-field-definition-by-name',@ref) )]">
-        <xsl:copy-of select="key('top-level-local-field-definition-by-name',@ref) "/>
+        <xsl:apply-templates mode="expand" select="key('top-level-local-field-definition-by-name',@ref) "/>
     </xsl:template>
     
     <xsl:template mode="acquire" match="flag[exists( key('top-level-local-flag-definition-by-name',@ref) )]">
-        <xsl:copy-of select="key('top-level-local-flag-definition-by-name',@ref) "/>
+        <xsl:apply-templates mode="expand" select="key('top-level-local-flag-definition-by-name',@ref) "/>
+    </xsl:template>
+    
+    <xsl:template match="*" mode="expand">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates mode="acquire"/>
+        </xsl:copy>
     </xsl:template>
     
     <xsl:template mode="acquire"

--- a/toolchains/xslt-M4/compose/testing/1_collected/collect-result.html
+++ b/toolchains/xslt-M4/compose/testing/1_collected/collect-result.html
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml">
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-      <title>Test Report for C:/Users/wap1/Documents/usnistgov/OSCAL/build/metaschema/toolchains/xslt-M4/compose/metaschema-collect.xsl (passed: 2 / pending: 0 / failed: 0 / total: 2)</title>
+      <title>Test Report for C:/Users/wap1/Documents/usnistgov/OSCAL/build/metaschema/toolchains/xslt-M4/compose/metaschema-collect.xsl (passed: 3 / pending: 0 / failed: 0 / total: 3)</title>
       <style type="text/css">/****************************************************************************/
 /*  File:       test-report.css                                             */
 /*  Author:     Jeni Tennison                                               */
@@ -511,7 +511,7 @@ span.scenario-totals {float: right; text-align: right}
       <h1>Test Report</h1>
       <p>Stylesheet: <a href="file:/C:/Users/wap1/Documents/usnistgov/OSCAL/build/metaschema/toolchains/xslt-M4/compose/metaschema-collect.xsl">C:/Users/wap1/Documents/usnistgov/OSCAL/build/metaschema/toolchains/xslt-M4/compose/metaschema-collect.xsl</a></p>
       <p>XSpec: <a href="file:/C:/Users/wap1/Documents/usnistgov/OSCAL/build/metaschema/toolchains/xslt-M4/compose/testing/1_collected/collect.xspec">C:/Users/wap1/Documents/usnistgov/OSCAL/build/metaschema/toolchains/xslt-M4/compose/testing/1_collected/collect.xspec</a></p>
-      <p>Tested: 16 October 2020 at 11:59</p>
+      <p>Tested: 20 October 2020 at 16:35</p>
       <h2>Contents</h2>
       <table class="xspec">
          <colgroup>
@@ -524,10 +524,10 @@ span.scenario-totals {float: right; text-align: right}
          <thead>
             <tr>
                <th></th>
-               <th class="totals">passed: 2</th>
+               <th class="totals">passed: 3</th>
                <th class="totals">pending: 0</th>
                <th class="totals">failed: 0</th>
-               <th class="totals">total: 2</th>
+               <th class="totals">total: 3</th>
             </tr>
          </thead>
          <tbody>
@@ -540,6 +540,13 @@ span.scenario-totals {float: right; text-align: right}
             </tr>
             <tr class="successful">
                <th><a href="#top_scenario2">Metaschema skeleton</a></th>
+               <th class="totals">1</th>
+               <th class="totals">0</th>
+               <th class="totals">0</th>
+               <th class="totals">1</th>
+            </tr>
+            <tr class="successful">
+               <th><a href="#top_scenario3">Nested locals</a></th>
                <th class="totals">1</th>
                <th class="totals">0</th>
                <th class="totals">0</th>
@@ -580,6 +587,25 @@ span.scenario-totals {float: right; text-align: right}
                </tr>
                <tr class="successful">
                   <td>Modules collected, no loops</td>
+                  <td>Success</td>
+               </tr>
+            </tbody>
+         </table>
+      </div>
+      <div id="top_scenario3">
+         <h2 class="successful">Nested locals<span class="scenario-totals">passed: 1 / pending: 0 / failed: 0 / total: 1</span></h2>
+         <table class="xspec" id="table_scenario3">
+            <colgroup>
+               <col style="width:75%" />
+               <col style="width:25%" />
+            </colgroup>
+            <tbody>
+               <tr class="successful">
+                  <th>Nested locals</th>
+                  <th>passed: 1 / pending: 0 / failed: 0 / total: 1</th>
+               </tr>
+               <tr class="successful">
+                  <td>Local definitions all expanded</td>
                   <td>Success</td>
                </tr>
             </tbody>

--- a/toolchains/xslt-M4/compose/testing/1_collected/collect.xspec
+++ b/toolchains/xslt-M4/compose/testing/1_collected/collect.xspec
@@ -67,6 +67,74 @@
             
         </x:expect>
     </x:scenario>
+    <x:scenario label="Nested locals">
+        <!-- Mysteriously, sometimes select="*" makes XSpec problems go away, other times not. -->
+        <x:context mode="acquire">
+            <METASCHEMA module="...">
+                <define-assembly name="root">
+                    <root-name>root-assembly</root-name>
+                    <flag ref="top-level-flag"/>
+                    <define-flag name="local-flag">
+                        <formal-name>Locally defined flag</formal-name>
+                        <description>XXX</description>
+                    </define-flag>
+                    <model>
+                        <field ref="top-level-global-field"/>
+                        <field ref="top-level-local-field"/>
+                        <assembly ref="top-level-local-assembly"/>
+                        <define-field name="local-field">
+                            <formal-name>Locally defined field</formal-name>
+                            <description>XXX</description>
+                        </define-field>
+                    </model>
+                </define-assembly>
+                <define-field name="top-level-global-field"/>
+                <define-field name="top-level-local-field" scope="local">
+                    <formal-name>Included twice</formal-name>
+                </define-field>
+                <define-assembly name="top-level-local-assembly" scope="local">
+                    <model>
+                        <field ref="top-level-local-field"/>
+                        <!-- ??? infinite loop? <assembly ref="top-level-local-assembly"/>-->
+                    </model>
+                </define-assembly>
+                <define-flag name="top-level-flag"/>                
+            </METASCHEMA>
+        </x:context>
+        <x:expect label="Local definitions all expanded">
+            <METASCHEMA module="...">
+                <define-assembly name="root">
+                    <root-name>root-assembly</root-name>
+                    <flag ref="top-level-flag"/>
+                    <define-flag name="local-flag">
+                        <formal-name>Locally defined flag</formal-name>
+                        <description>XXX</description>
+                    </define-flag>
+                    <model>
+                        <field ref="top-level-global-field"/>
+                        <define-field name="top-level-local-field" scope="local">
+                            <formal-name>Included twice</formal-name>
+                        </define-field>
+                        <define-assembly name="top-level-local-assembly" scope="local">
+                            <model>
+                                <define-field name="top-level-local-field" scope="local">
+                                    <formal-name>Included twice</formal-name>
+                                </define-field>
+                            </model>
+                        </define-assembly>
+                        <define-field name="local-field">
+                            <formal-name>Locally defined field</formal-name>
+                            <description>XXX</description>
+                        </define-field>
+                    </model>
+                </define-assembly>
+                <define-field name="top-level-global-field"/>
+                
+                <define-flag name="top-level-flag"/>                
+            </METASCHEMA>
+            
+        </x:expect>
+    </x:scenario>
     
     
 </x:description>

--- a/toolchains/xslt-M4/document/metaschema-htmldoc-xslt1.xsl
+++ b/toolchains/xslt-M4/document/metaschema-htmldoc-xslt1.xsl
@@ -49,7 +49,7 @@
       <li class="prose">Prose contents (paragraphs and lists)</li>
    </xsl:template>
 
-   <xsl:template match="m:allowed-values">
+   <xsl:template match="m:allowed-values" name="allowed-values">
       <xsl:choose>
         <xsl:when test="@allow-other and @allow-other='yes'">
           <p>The value may be locally defined, or one of the following:</p>

--- a/toolchains/xslt-M4/document/xml/xml-docs-hugo-uswds.xsl
+++ b/toolchains/xslt-M4/document/xml/xml-docs-hugo-uswds.xsl
@@ -12,6 +12,8 @@
    <!-- Input:   Metaschema -->
    <!-- Output:  HTML  -->
 
+   <xsl:import href="../metaschema-common-html.xsl"/>
+
    <xsl:param name="schema-path" select="document-uri(/)"/>
 
    <xsl:variable name="metaschema-code" select="/*/short-name || '-xml'"/>
@@ -24,233 +26,23 @@
 
    <xsl:output indent="yes"/>
 
-
-   <!-- Purpose: XSLT 3.0 stylesheet for Metaschema display (HTML): common code -->
-   <!-- Input:   Metaschema -->
-   <!-- Output:  HTML  -->
-   
-   <xsl:import href="../metaschema-htmldoc-xslt1.xsl"/>
-   
-   <xsl:variable name="home" select="/METASCHEMA"/>
-   
-   <xsl:variable name="all-references" select="//flag/@name | //model//*/@ref"/>
-   
-   <xsl:key name="definitions" match="/METASCHEMA/define-flag | /METASCHEMA/define-field | /METASCHEMA/define-assembly" use="@name"/>
-   <xsl:key name="references" match="flag"             use="@name | @ref"/>
-   <xsl:key name="references" match="field | assembly" use="@ref"/>
-   
-   <xsl:template match="/">
-      <html>
-         <head>
-            <xsl:call-template name="css"/>
-         </head>
-         <body>
-            <section>
-               <xsl:for-each-group select="//constraint/(.|descendant::require)/(child::* except child::require)" group-by="m:path-key((@target,'.')[1])" expand-text="true">
-                  <details>
-                     <summary>Path key { current-grouping-key() }</summary>
-                     <xsl:apply-templates select="current-group()" mode="build-index"/>
-                  </details>
-               </xsl:for-each-group> 
-            </section>
-            <xsl:apply-templates/>
-         </body>
-      </html>
-   </xsl:template>
-   
-   <xsl:template mode="build-index" match="*">
-      <details class="constraint-index">
-         <xsl:apply-templates select=".." mode="constraint-context"/>
-         <xsl:apply-templates select="."/>
-      </details>
-   </xsl:template>
-   
-   <xsl:template match="*" mode="constraint-context">
-      <summary>In <xsl:apply-templates select="ancestor::define-assembly | ancestor::define-field | ancestor::define-flag" mode="read-context"/>
-      <xsl:apply-templates select="ancestor::require" mode="read-context"/>
-      </summary>
-   </xsl:template>
-   
-   <xsl:template match="define-assembly | define-field | define-flag" mode="read-context">
-      <xsl:if test="position() gt 1">/</xsl:if>
-      <xsl:apply-templates select="@name"/>
-   </xsl:template>
-   
-   <xsl:template match="require" mode="read-context">
-      <xsl:text> when </xsl:text>
-      <code>
-        <xsl:apply-templates select="@when"/>
-      </code>
-   </xsl:template>
-   
-   
-   <xsl:template match="METASCHEMA">
-      <xsl:variable name="definitions" select="define-assembly | define-field | define-flag"/>
-      <div class="{$metaschema-code ! replace(.,'.*-','') }-docs">
-         <div class="top-level">
-            <p><span class="usa-tag">Schema download</span>
-               <xsl:text> </xsl:text>
-               <a href="{$schema-path}">
-                  <xsl:value-of select="replace($schema-path,'^.*/','')"/></a>
-            </p>
-            <xsl:apply-templates select="* except $definitions"/>
-         </div>
-         <xsl:apply-templates select="child::define-assembly" mode="make-definition">
-            <xsl:with-param name="make-page-links" tunnel="true" select="true()"/>
-         </xsl:apply-templates>
-      </div>
-   </xsl:template>
-   
-   
-   <xsl:template match="METASCHEMA/schema-name"/>
-   
-   <xsl:template match="METASCHEMA/namespace">
-      <p>
-         <span class="label">XML namespace</span>
-         <xsl:text> </xsl:text>
-         <code>
-            <xsl:apply-templates/>
-         </code>
-      </p>
-   </xsl:template>
-   
-   <xsl:template match="description">
-      <p class="description">
-         <span class="usa-tag">Description</span>
-         <xsl:text> </xsl:text>
-         <xsl:apply-templates/>
-      </p>
-   </xsl:template>
-   
-   <xsl:template match="define-assembly | define-field | define-flag" mode="link-here">
-      <a href="#{@name}"><xsl:value-of select="@name"/></a>
-   </xsl:template>
-   
-   <xsl:template match="*[exists(@ref)]" mode="link-here">
-      <a href="#{@ref}"><xsl:value-of select="@ref"/></a>
-   </xsl:template>
-   
-   <xsl:template name="definition-header">
-      <xsl:param name="using-names" select="
-         if (exists(root-name)) then (root-name,use-name) else (if (exists(use-name)) then use-name else key('references',@name)/use-name)"/>
-      <header class="definition-header">
-         <xsl:call-template name="cross-links"/>
-         <h2 id="{$metaschema-code}_{@name}" class="{substring-after(local-name(),'define-')}-header">
-            <xsl:apply-templates select="(root-name,use-name,@name)[1]" mode="tag"/>
-            <xsl:if test="$using-names"> (</xsl:if>
-            <xsl:for-each-group select="$using-names" group-by="string(.)">
-               <xsl:if test="position() gt 1">, </xsl:if>
-               <code>
-                  <xsl:value-of select="current-grouping-key()"/>
-               </code>
-            </xsl:for-each-group>
-            <xsl:if test="$using-names">)</xsl:if>
-         </h2>
-      </header>
-      <xsl:apply-templates select="formal-name" mode="header"/>
-   </xsl:template>
-   
-   <xsl:template match="formal-name" mode="header">
-      <p class="formal-name">
-         <span class="usa-tag">Name</span>
-         <xsl:text> </xsl:text>
-         <xsl:apply-templates/>
-      </p>
-   </xsl:template>
-   
-   <xsl:template name="remarks-group">
-      <!-- can't use xsl:where-populated due to the header :-( -->
-      <xsl:for-each-group select="remarks[not(@class != 'xml')]" group-by="true()">
-         <details class="remarks-group">
-            <summary class="h4"><span class="usa-tag">Remarks</span></summary>
-            <xsl:apply-templates select="current-group()"/>
-         </details>
-      </xsl:for-each-group>
-   </xsl:template>
-   
-   <xsl:template match="code[. = (/*/@name except ancestor::*/@name)]">
-      <a href="#{.}">
-         <xsl:next-match/>
-      </a>
-   </xsl:template>
-   
-   <!--<xsl:template mode="tag" match="@name">
-         <code class="tagging"><xsl:value-of select="."/></code>   
-      </xsl:template>
-      
-      <xsl:template mode="tag" match="root-name | use-name">
-         <code class="tagging"><xsl:value-of select="."/></code>   
-      </xsl:template>-->
-   
-   
-   <!--<xsl:variable name="github-base" as="xs:string">https://github.com/usnistgov/OSCAL/tree/master</xsl:variable>-->
-   
-   <xsl:template name="report-module"/>
-   
-   <!--<xsl:template name="report-module-really">
-         <xsl:variable name="metaschema-path" select="substring-after(.,'OSCAL/')"/>
-      <xsl:for-each select="@module">
-         <p class="text-accent-warm-darker" xsl:expand-text="yes">
-            <xsl:text>Module defined: </xsl:text>
-            <a href="{ $github-base}/{ $metaschema-path}">{
-               replace(.,'.*/','') }</a></p>
-      </xsl:for-each>
-   </xsl:template>-->
-   
-   <xsl:template match="example[empty(* except (description | remarks))]"/>
-   
-   
-   <xsl:template name="css">
-      <style type="text/css">
-         <xsl:sequence select="unparsed-text('../hugo-uswds.css','utf-8') ! replace(.,'#xD;','')"/>
-      </style>
-   </xsl:template>
-   
-   <xsl:template mode="occurrence-code" match="*">
-      <xsl:variable name="minOccurs" select="(@min-occurs,'0')[1]"/>
-      <xsl:variable name="maxOccurs" select="(@max-occurs,'1')[1] ! (if (. eq 'unbounded') then '&#x221e;' else .)"/>
-      <i class="occurrence">
-         <xsl:text>[</xsl:text>
-         <xsl:choose>
-            <xsl:when test="$minOccurs = $maxOccurs" expand-text="true">{ $minOccurs }</xsl:when>
-            <xsl:when test="number($maxOccurs) = number($minOccurs) + 1" expand-text="true">{ $minOccurs } or { $maxOccurs }</xsl:when>
-            <xsl:otherwise expand-text="true">{ $minOccurs } to { $maxOccurs }</xsl:otherwise>
-         </xsl:choose>
-         <xsl:text>]</xsl:text>
-      </i>
-   </xsl:template>
-   
-   <!-- Returns true when a field must become an object, not a string, due to having
-     flags that must be properties. -->
-   <xsl:function name="m:has-properties" as="xs:boolean">
-      <xsl:param name="who" as="element()"/>
-      <xsl:sequence select="exists($who/(define-flag|flag)[not((@name|@ref)=../(json-key | json-value-key)/@flag-name)])"/>
-   </xsl:function>
-   
    <!-- ^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V^V -->
 
    <xsl:template name="cross-links">
-      <xsl:param name="make-page-links" select="false()" tunnel="true"/>
       <xsl:variable name="schema-base" select="replace($metaschema-code,'-xml$','')"/>
-      <xsl:if test="$make-page-links">
       <div class="crosslink">
          <a href="../json-schema/#{$schema-base}-json_{ @name}">
             <button class="schema-link">Switch to JSON</button>
          </a>
       </div>
-      </xsl:if>
    </xsl:template>
 
-   <xsl:function name="m:path-key" as="xs:string">
-      <xsl:param name="path" as="xs:string"/>
-      <xsl:sequence select="replace($path,'^.*/','') => replace('\[.*$','')"/>
-   </xsl:function>
-   
-   <xsl:template match="define-flag" mode="make-definition">
+   <xsl:template match="define-flag">
       <div class="definition define-flag" id="{@name}">
          <xsl:call-template name="definition-header"/>
          <xsl:apply-templates select="description"/>
          <xsl:apply-templates select="." mode="representation-in-xml"/>
+         <xsl:apply-templates select="constraint/allowed-values"/>
          <xsl:for-each-group select="key('references',@name)/parent::*" group-by="true()">
             <p><xsl:text>This attribute appears on: </xsl:text>
                <xsl:for-each-group select="current-group()" group-by="(@ref|@name)">
@@ -259,20 +51,19 @@
                   <xsl:apply-templates select="." mode="link-here"/>
                </xsl:for-each-group>.</p>
          </xsl:for-each-group>
-         <xsl:apply-templates select="constraint"/>
          <xsl:call-template name="remarks-group"/>
          <xsl:call-template name="report-module"/>
       </div>
    </xsl:template>
 
-   <xsl:template match="define-field" mode="make-definition">
+   <xsl:template match="define-field">
       <div class="definition define-field" id="{@name}">
          <xsl:call-template name="definition-header"/>
          <xsl:apply-templates select="formal-name | description"/>
          <xsl:apply-templates mode="representation-in-xml" select="."/>
+         <xsl:apply-templates select="constraint/allowed-values"/>
          <xsl:call-template name="appears-in"/>
          <xsl:call-template name="flags-for-field"/>
-         <xsl:apply-templates select="constraint"/>
          <xsl:call-template name="remarks-group"/>
          <xsl:apply-templates select="example"/>
          <xsl:call-template name="report-module"/>
@@ -307,7 +98,7 @@
       </xsl:if>
    </xsl:template>
 
-   <xsl:template match="define-assembly" mode="make-definition">
+   <xsl:template match="define-assembly">
       <div class="definition define-assembly" id="{@name}">
          <xsl:call-template name="definition-header"/>
          <xsl:apply-templates select="formal-name | description"/>
@@ -315,36 +106,13 @@
             <h5><code xsl:expand-text="true">{ . }</code> is a root (containing) element in this schema. </h5>
          </xsl:for-each>
          <xsl:call-template name="appears-in"/>
-         <xsl:for-each-group select="define-flag | flag" group-by="true()">
-            <xsl:where-populated>
-               <div class="model attributes">
-                  <h4>Attributes:</h4>
-                  <ul>
-                     <xsl:apply-templates select="current-group()">
-                        <xsl:with-param name="make-page-links" tunnel="true" select="false()"/>
-                     </xsl:apply-templates>
-                  </ul>
-               </div>
-            </xsl:where-populated>
-         </xsl:for-each-group>
          <xsl:apply-templates select="model"/>
-         <xsl:apply-templates select="constraint"/>
          <xsl:call-template name="remarks-group"/>
          <xsl:apply-templates select="example"/>
          <xsl:call-template name="report-module"/>
-         <xsl:variable name="local-definitions" as="element()*">
-            <xsl:apply-templates select="model" mode="make-definition">
-               <xsl:with-param tunnel="true" name="make-page-links" select="false()"/>
-            </xsl:apply-templates>
-         </xsl:variable>
-         <xsl:if test="exists($local-definitions)" expand-text="true">
-         <details style="background-color: lightblue; border: thin solid midnightblue; padding: 0.5em">
-            <summary class="h5">Local element definitions</summary>
-            <xsl:sequence select="$local-definitions"/>
-         </details>
-         </xsl:if>
       </div>
    </xsl:template>
+
 
    <xsl:template name="appears-in">
       <xsl:for-each-group select="key('references', @name)/ancestor::model/parent::*"
@@ -364,20 +132,15 @@
       </code>
    </xsl:template>
 
-   <xsl:template match="*[use-name|root-name]/@name | *[use-name]/@ref">
-      <code>
-         <xsl:apply-templates select="parent::*/use-name"/>
-      </code>
-   </xsl:template>
-   
-   
    <xsl:template match="define-flag/@name | flag/@name">
       <code>
          <xsl:value-of select="."/>
       </code>
    </xsl:template>
 
-   <xsl:template match="flag | define-flag">
+   <xsl:template match="flag"/>
+
+   <xsl:template match="flag | define-flag" mode="model">
       <li class="model-entry">
          <p>
             <xsl:apply-templates mode="link-here" select="key('definitions', @ref)"/>
@@ -391,12 +154,8 @@
             <xsl:apply-templates select="." mode="requirement"/>
             <xsl:apply-templates select="if (description) then description else key('definitions', @ref)/description" mode="model"/>
          </p>
-         <xsl:apply-templates select="constraint"/>
+         <xsl:call-template name="allowed-values"/>
          <xsl:apply-templates select="remarks" mode="model"/>
-         <!--<details>
-            <summary><span class="usa-tag">Definition</span></summary>
-            <xsl:apply-templates select="." mode="make-definition"/>
-         </details>-->
       </li>
    </xsl:template>
 
@@ -412,12 +171,11 @@
 
    <xsl:template match="model">
       <div class="model">
-         <p>Contains<xsl:if
+         <p>The <xsl:apply-templates select="../@name"/> element has the following contents<xsl:if
                test="count(*) > 1"> (in order)</xsl:if>:</p>
          <ul>
-            <xsl:apply-templates>
-               <xsl:with-param name="make-page-links" tunnel="true" select="false()"/>
-            </xsl:apply-templates>
+            <xsl:apply-templates select="../(define-flag | flag)" mode="model"/>
+            <xsl:apply-templates/>
          </ul>
       </div>
    </xsl:template>
@@ -426,7 +184,7 @@
       <li>Any element (in a foreign namespace)</li>
    </xsl:template>
 
-   <xsl:template match="assembly">
+   <xsl:template match="assembly | field">
       <li class="model-entry">
          <p>
             <!--<xsl:text>A</xsl:text>
@@ -441,177 +199,31 @@
             <xsl:apply-templates mode="model"
                select="if (description) then description else key('definitions', @ref)/description"/>
          </p>
+         <xsl:call-template name="allowed-values"/>
          <xsl:apply-templates select="remarks" mode="model"/>
       </li>
    </xsl:template>
    
-   <xsl:template match="constraint" expand-text="true">
-      <div class="constraint-set" style="background-color: pink; padding: 0.5em; margin: 0.5em; border: thin solid red">
-         <xsl:variable name="constraints" select=".//allowed-values | .//matches | .//has-cardinality | .//is-unique | .//index-has-key"/>
-         <h4 class="h4"><span class="usa-tag">{ if (count($constraints) eq 1) then 'constraint' else 'constraints'}</span></h4>
-         <xsl:apply-templates/>
-      </div>
-   </xsl:template>
-   
-   <xsl:template match="constraint/*">
-      <div class="constraint">
-         <xsl:value-of select="local-name(),(@* ! ( local-name() || ':' || .))" separator=" "/>
-         <xsl:apply-templates/>
-      </div>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="require" expand-text="true">
-      <div class="requirement" style="padding: 0.5em; border: thin dotted black">
-         <p>When <code>{ @when}</code>:</p>
-         <xsl:apply-templates/>
-      </div>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="allowed-values[empty(@target) or @target=('.','value()')]">
-      <xsl:choose expand-text="true">
-         <xsl:when test="@allow-other and @allow-other='yes'">
-            <p><span class="usa-tag">allowed value</span> The value may be locally defined, or one of the following:</p>
-         </xsl:when>
-         <xsl:otherwise>
-            <p><span class="usa-tag">allowed value</span> The value must be one of the following:</p>
-         </xsl:otherwise>
-      </xsl:choose>
-      <ul>
-         <xsl:apply-templates/>
-      </ul>   
-   </xsl:template>
-   
-   <xsl:template priority="2" match="allowed-values[exists(@target) and not(@target=('.','value()'))]" expand-text="true">
-      <xsl:variable name="target" select="@target[not(.=('.','value()'))]"/>
-      <xsl:choose expand-text="true">
-         <xsl:when test="@allow-other and @allow-other='yes'">
-            <p><span class="usa-tag">allowed value</span> On target <code>{ @target }</code>, the value may be locally defined, or one of the following:</p>
-         </xsl:when>
-         <xsl:otherwise>
-            <p><span class="usa-tag">allowed value</span> On target <code>{ @target }</code>, the value must be one of the following:</p>
-         </xsl:otherwise>
-      </xsl:choose>
-      <ul>
-         <xsl:apply-templates/>
-      </ul>   
-   </xsl:template>
-   
-   <xsl:template priority="2" match="matches[@regex][empty(@target) or @target=('.','value()')]" expand-text="true">
-      <xsl:variable name="target" select="@target[not(.=('.','value()'))]"/>
-      <p><span class="usa-tag">match constraint</span> In this scope, the values must match the regular expression '{ @regex }'.</p>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="matches[@regex][exists(@target) and not(@target=('.','value()'))]" expand-text="true">
-      <p><span class="usa-tag">match constraint</span> In this scope, the value(s) of target(s) <code>{ @target }</code> must match the regular expression '{ @regex }'.</p>
-   </xsl:template>
-   
-   
-   
-   <xsl:template priority="2" match="matches[@datatype][empty(@target) or @target=('.','value()')]" expand-text="true">
-      <p><span class="usa-tag">match constraint</span> In this scope, the value must match the lexical form of the '{ @datatype }' data type.</p>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="matches[@datatype][exists(@target) and not(@target=('.','value()'))]" expand-text="true">
-      <p><span class="usa-tag">match constraint</span> In this scope, the value(s) of target(s) <code>{ @target }</code> must match the lexical form of the '{ @datatype }' data type.</p>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="is-unique[empty(@target) or @target=('.','value()')]" expand-text="true">
-      <xsl:variable name="target" select="@target[not(.=('.','value()'))]"/>
-      <p><span class="usa-tag">uniqueness constraint</span> In this scope, the value must be unique (i.e., occur only once)</p>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="has-cardinality" expand-text="true">
-      <p><span class="usa-tag">cardinality constraint</span> Within this scope, the cardinality of <code>{ @target }</code> is constrained:
-         minimum <b>{ (@min-occurs,0)[1] }</b>; maximum <b>{ (@max-occurs,'unbounded')[1]}</b>.</p>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="is-unique[exists(@target) or not(@target=('.','value()'))]" expand-text="true">
-      <xsl:variable name="target" select="@target[not(.=('.','value()'))]"/>
-      <p><span class="usa-tag">uniqueness constraint</span> In this scope, the value of target(s) <code>{ @target }</code> must be unique (i.e., occur only once)</p>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="index-has-key[empty(@target) or @target=('.','value()')]" expand-text="true">
-      <xsl:variable name="target" select="@target[not(.=('.','value()'))]"/>
-      <p><span class="usa-tag">indexing constraint</span> This value must correspond to a listing in the index <code>{ @name }</code>
-         <xsl:text> using a key constructed of key field(s) </xsl:text>
-         <xsl:for-each select="key-field"><xsl:if test="position() gt 1">; </xsl:if><code><xsl:value-of select="@target"/></code></xsl:for-each>.</p>
-      <xsl:apply-templates/>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="index-has-key[exists(@target) and not(@target=('.','value()'))]" expand-text="true">
-      <p><span class="usa-tag">indexing constraint</span> In this scope, any '{ @target }' must be listed in the index<code>{ @name }</code>
-         <xsl:text> using a key constructed of key field(s) </xsl:text>
-         <xsl:for-each select="key-field"><xsl:if test="position() gt 1">; </xsl:if><code><xsl:value-of select="@target"/></code></xsl:for-each>.</p>
-      <xsl:apply-templates/>
-   </xsl:template>
-   
-   <xsl:template priority="2" match="index" expand-text="true">
-      <p><span class="usa-tag">index definition</span> For this scope, an index <code>{ @name }</code> shall list values returned by <code>{ @target}</code>
-         <xsl:text> using keys constructed of key field(s) </xsl:text>
-         <xsl:for-each select="key-field"><xsl:if test="position() gt 1">; </xsl:if><code><xsl:value-of select="@target"/></code></xsl:for-each>.</p>
-      <xsl:apply-templates/>
-   </xsl:template>
-   
-   <xsl:template match="define-assembly | define-field">
+   <xsl:template match="model//define-field">
       <li class="model-entry">
          <p>
             <!--<xsl:text>A</xsl:text>
          <xsl:if test="not(translate(substring(@ref, 1, 1), 'AEIOUaeiuo', ''))">n</xsl:if>
          <xsl:text> </xsl:text>-->
-            <xsl:apply-templates select="@name"/>
-            
+            <a href="#{@name}">
+               <xsl:apply-templates select="(use-name,@name)[1]"/>
+            </a>
             <xsl:text expand-text="true"> element{ if (@max-occurs != '1') then 's' else '' } </xsl:text>
             <xsl:apply-templates select="." mode="metaschema-type"/>
             <xsl:apply-templates select="." mode="occurrence-code"/>
             <xsl:apply-templates mode="model"
-               select="if (description) then description else key('definitions', @ref)/description"/>
+               select="description"/>
          </p>
-         <xsl:apply-templates select="constraint"/>
+         <xsl:apply-templates select="constraint/allowed-values"/>
          <xsl:apply-templates select="remarks" mode="model"/>
-         <!--<details>
-            <summary><span class="usa-tag">Definition</span></summary>
-            <xsl:apply-templates select="." mode="make-definition"/>
-         </details>-->
+         <xsl:call-template name="flags-for-field"/>
       </li>
    </xsl:template>
-   
-   <xsl:template match="define-field[@as-type='markup-multiline'][@in-xml='UNWRAPPED']">
-      <li class="model-entry">
-         <p>An optional sequence of prose (markup) elements including <code>p</code>, lists, tables and headers (<code>h1-h6</code>).</p>
-         <!--<details>
-            <summary>Definition</summary>
-            <xsl:apply-templates select="." mode="make-definition"/>
-         </details>-->
-      </li>
-   </xsl:template>
-   
-   <xsl:template match="field">
-      <li class="model-entry">
-         <p>
-            <!--<xsl:text>A</xsl:text>
-         <xsl:if test="not(translate(substring(@ref, 1, 1), 'AEIOUaeiuo', ''))">n</xsl:if>
-         <xsl:text> </xsl:text>-->
-            <xsl:apply-templates select="@ref"/>
-            <xsl:text expand-text="true"> element{ if (@max-occurs != '1') then 's' else '' } </xsl:text>
-            <xsl:apply-templates select="." mode="metaschema-type"/>
-            <xsl:apply-templates select="." mode="occurrence-code"/>
-            <xsl:apply-templates mode="model"
-               select="if (description) then description else key('definitions', @ref)/description"/>
-         </p>
-         <xsl:apply-templates select="remarks" mode="model"/>
-         <!--<details>
-            <summary>Definition</summary>
-            <xsl:apply-templates select="." mode="make-definition"/>
-         </details>-->
-      </li>
-   </xsl:template>  
-   
-   <xsl:template mode="make-definition" match="field | flag | assembly"/>
-   
-   <!--<xsl:template mode="make-definition" match="field | flag | assembly"/>
-      <xsl:apply-templates select="key('definitions',@ref)" mode="make-definition"/>
-   </xsl:template>-->
-   
    
    <!-- remarks are kept if @class='xml' or no class is given -->
    <xsl:template match="remarks[@class != 'xml']" priority="2"/>
@@ -717,7 +329,7 @@
    </xsl:template>
 
    <xsl:template match="define-field" mode="representation-in-xml">
-      <xsl:variable name="unwrapped-references" select=".[@in-xml='UNWRAPPED'] | key('references',@name)[@in-xml='UNWRAPPED']"/>
+      <xsl:variable name="unwrapped-references" select="key('references',@name)[@in-xml='UNWRAPPED']"/>
       <p>An element<xsl:apply-templates select="." mode="metaschema-type"/></p>
 
       <xsl:if test="exists($unwrapped-references)">
@@ -759,8 +371,4 @@
       <xsl:message>Matching <xsl:value-of select="local-name()"/></xsl:message>
    </xsl:template>
 
-   
-      
-            
-   
 </xsl:stylesheet>

--- a/toolchains/xslt-M4/validate/metaschema-check.sch
+++ b/toolchains/xslt-M4/validate/metaschema-check.sch
@@ -67,7 +67,7 @@
             <sch:let name="references" value="nm:references-to-definition(.)"/>
             <sch:report test="@name=(../*/@name except @name)">Definition for '<sch:value-of select="@name"/>' clashes in this metaschema: not a good idea.</sch:report>
             <!--<sch:assert role="warning" test="exists($references | self::m:define-assembly/m:root-name) and ( not($metaschema-is-abstract or @scope='local') )">-->
-            <sch:assert role="warning" test="exists($references | self::m:define-assembly/m:root-name) or $metaschema-is-abstract">Orphan <sch:value-of select="substring-after(local-name(),'define-')"/> '<sch:value-of select="@name"/>' is never used in the composed metaschema</sch:assert>
+            <sch:assert role="warning" test="exists($references | self::m:define-assembly/m:root-name) or $metaschema-is-abstract or (@scope='local')">Orphan <sch:value-of select="substring-after(local-name(),'define-')"/> '<sch:value-of select="@name"/>' is never used in the composed metaschema</sch:assert>
             
             <sch:assert test="not($references/m:group-as/@in-json='BY_KEY') or exists(m:json-key)"><sch:value-of select="substring-after(local-name(),
             'define-')"/> is assigned a json key, but no 'json-key' is given</sch:assert>


### PR DESCRIPTION
# Committer Notes

Corrects bug in XSD generation when chains of definition calls declared with scope='local' were not expanded all the way down.

The implementation in the PR correctly expands all the way -- but *does not defend against infinite loops*.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass? **TBD**

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
