### PR TITLE
JSON Schema generation repair, with other adjustments

### DIFF
--- a/test-suite/schema-generation/group-as/group-as-by-key_json-schema.json
+++ b/test-suite/schema-generation/group-as/group-as-by-key_json-schema.json
@@ -16,8 +16,7 @@
             "additionalProperties" : 
             { "allOf" : 
               [ 
-                { "type" : "object",
-                  "$ref" : "#/definitions/prop" },
+                { "$ref" : "#/definitions/prop" },
                 
                 { "not" : 
                   { "type" : "string" } } ] } } },

--- a/test-suite/schema-generation/group-as/group-as-misc_json-schema.json
+++ b/test-suite/schema-generation/group-as/group-as-misc_json-schema.json
@@ -1,0 +1,123 @@
+
+  { "$schema" : "http://json-schema.org/draft-07/schema#",
+    "$id" : "http://csrc.nist.gov/ns/metaschema/unit-test/group-as-by-key-schema.json",
+    "$comment" : "Metaschema Unit Test: group-as: JSON Schema",
+    "type" : "object",
+    "definitions" : 
+    { "root" : 
+      { "title" : "Root",
+        "description" : "...",
+        "$id" : "#/definitions/root",
+        "type" : "object",
+        "properties" : 
+        { "information-types" : 
+          { "type" : "array",
+            "minItems" : 1,
+            "items" : 
+            { "title" : "Information Type",
+              "description" : "Contains details about one information type that is stored, processed, or transmitted by the system, such as privacy information, and those defined in NIST SP 800-60.",
+              "$id" : "#/definitions/information-type",
+              "type" : "object",
+              "properties" : 
+              { "uuid" : 
+                { "title" : "Information Type Universally Unique Identifier",
+                  "description" : "A globally unique identifier that can be used to reference this information type entry elsewhere in an OSCAL document. A UUID should be consistantly used for a given resource across revisions of the document.",
+                  "type" : "string",
+                  "pattern" : "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$" },
+                "title" : 
+                { "title" : "title field",
+                  "description" : "A human readable name for the information type. This title should be meaningful within the context of the system.",
+                  "$id" : "#/definitions/title",
+                  "type" : "string" },
+                "description" : 
+                { "title" : "Information Type Description",
+                  "description" : "A summary of how this information type is used within the system.",
+                  "$id" : "#/definitions/description",
+                  "type" : "string" },
+                "information-type-ids" : 
+                { "type" : "object",
+                  "minProperties" : 1,
+                  "additionalProperties" : 
+                  { "allOf" : 
+                    [ 
+                      { "title" : "Information Type Identifier",
+                        "description" : "An identifier qualified by the given identification system used, such as NIST SP 800-60.",
+                        "$id" : "#/definitions/information-type-id",
+                        "type" : "object",
+                        "properties" : 
+                        { "id" : 
+                          { "type" : "string" } },
+                        "required" : 
+                        [ "id" ],
+                        "additionalProperties" : false },
+                      
+                      { "not" : 
+                        { "type" : "string" } } ] } },
+                "confidentiality-impact" : 
+                { "title" : "Confidentiality Impact Level",
+                  "description" : "The expected level of impact resulting from the unauthorized disclosure of information.",
+                  "$id" : "#/definitions/confidentiality-impact",
+                  "type" : "object",
+                  "properties" : 
+                  { "base" : 
+                    { "title" : "Base Level (Confidentiality, Integrity, or Availability)",
+                      "description" : "The prescribed base (Confidentiality, Integrity, or Availability) security impact level.",
+                      "$id" : "#/definitions/base",
+                      "type" : "string" },
+                    "selected" : 
+                    { "title" : "Selected Level (Confidentiality, Integrity, or Availability)",
+                      "description" : "The selected (Confidentiality, Integrity, or Availability) security impact level.",
+                      "$id" : "#/definitions/selected",
+                      "type" : "string" } },
+                  "additionalProperties" : false },
+                "integrity-impact" : 
+                { "title" : "Integrity Impact Level",
+                  "description" : "The expected level of impact resulting from the unauthorized modification of information.",
+                  "$id" : "#/definitions/integrity-impact",
+                  "type" : "object",
+                  "properties" : 
+                  { "base" : 
+                    { "title" : "Base Level (Confidentiality, Integrity, or Availability)",
+                      "description" : "The prescribed base (Confidentiality, Integrity, or Availability) security impact level.",
+                      "$id" : "#/definitions/base",
+                      "type" : "string" },
+                    "selected" : 
+                    { "title" : "Selected Level (Confidentiality, Integrity, or Availability)",
+                      "description" : "The selected (Confidentiality, Integrity, or Availability) security impact level.",
+                      "$id" : "#/definitions/selected",
+                      "type" : "string" } },
+                  "additionalProperties" : false },
+                "availability-impact" : 
+                { "title" : "Availability Impact Level",
+                  "description" : "The expected level of impact resulting from the disruption of access to or use of information or the information system.",
+                  "$id" : "#/definitions/availability-impact",
+                  "type" : "object",
+                  "properties" : 
+                  { "base" : 
+                    { "title" : "Base Level (Confidentiality, Integrity, or Availability)",
+                      "description" : "The prescribed base (Confidentiality, Integrity, or Availability) security impact level.",
+                      "$id" : "#/definitions/base",
+                      "type" : "string" },
+                    "selected" : 
+                    { "title" : "Selected Level (Confidentiality, Integrity, or Availability)",
+                      "description" : "The selected (Confidentiality, Integrity, or Availability) security impact level.",
+                      "$id" : "#/definitions/selected",
+                      "type" : "string" } },
+                  "additionalProperties" : false } },
+              "required" : 
+              [ "title",
+                "description",
+                "confidentiality-impact",
+                "integrity-impact",
+                "availability-impact" ],
+              "additionalProperties" : false } } },
+        "required" : 
+        [ "information-types" ],
+        "additionalProperties" : false } },
+    "properties" : 
+    { "root" : 
+      { "$ref" : "#/definitions/root" } },
+    "required" : 
+    [ "root" ],
+    "additionalProperties" : false,
+    "maxProperties" : 1 }

--- a/test-suite/schema-generation/group-as/group-as-misc_metaschema.xml
+++ b/test-suite/schema-generation/group-as/group-as-misc_metaschema.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../../toolchains/xslt-M4/validate/metaschema-check.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<!-- OSCAL CATALOG METASCHEMA -->
+<!-- validate with XSD and Schematron (linked) -->
+<METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+   xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../../toolchains/xslt-M4/validate/metaschema.xsd">
+   <schema-name>Metaschema Unit Test: group-as</schema-name>
+   <schema-version>1.0-milestone1</schema-version>
+   <short-name>metaschema-group-as</short-name>
+   <namespace>http://csrc.nist.gov/ns/metaschema/unit-test/group-as-by-key</namespace>
+   
+   <!-- Metaschema exposes a bug repaired Nov 4 2020 produced by group-as[@in-json='BY_KEY']  -->
+   
+   <define-assembly name="root">
+      <formal-name>Root</formal-name>
+      <description>...</description>
+      <root-name>root</root-name>
+      <model>
+         <define-assembly name="information-type" min-occurs="1" max-occurs="unbounded">
+            <formal-name>Information Type</formal-name>
+            <description>Contains details about one information type that is stored, processed, or
+               transmitted by the system, such as privacy information, and those defined in <a
+                  href="https://doi.org/10.6028/NIST.SP.800-60v2r1">NIST SP
+               800-60</a>.</description>
+            <group-as name="information-types" in-json="ARRAY"/>
+
+            <define-flag name="uuid" as-type="uuid">
+               <formal-name>Information Type Universally Unique Identifier</formal-name>
+               <description>A globally unique identifier that can be used to reference this
+                  information type entry elsewhere in an OSCAL document. A UUID should be
+                  consistantly used for a given resource across revisions of the
+                  document.</description>
+            </define-flag>
+            <model>
+               <define-field name="title" as-type="markup-line" min-occurs="1">
+                  <formal-name>title field</formal-name>
+                  <description>A human readable name for the information type. This title should be
+                     meaningful within the context of the system.</description>
+               </define-field>
+               <define-field name="description" as-type="markup-multiline" min-occurs="1"
+                  in-xml="WITH_WRAPPER">
+                  <formal-name>Information Type Description</formal-name>
+                  <description>A summary of how this information type is used within the
+                     system.</description>
+               </define-field>
+               <define-field name="information-type-id" as-type="string" max-occurs="unbounded">
+                  <formal-name>Information Type Identifier</formal-name>
+                  <description>An identifier qualified by the given identification
+                     <code>system</code> used, such as NIST SP 800-60.</description>
+                  <json-key flag-name="system"/>
+                  <json-value-key>id</json-value-key>
+                  <group-as name="information-type-ids" in-json="BY_KEY"/>
+                  <define-flag required="yes" name="system">
+                     <formal-name>Information Type Identification System</formal-name>
+                     <description>Specifies the information type identification system
+                        used.</description>
+                     <constraint>
+                        <allowed-values allow-other="yes">
+                           <enum value="https://doi.org/10.6028/NIST.SP.800-60v2r1">Based on the
+                              section identifiers in NIST Special Publication 800-60 Volume II
+                              Revision 1</enum>
+                        </allowed-values>
+                     </constraint>
+                  </define-flag>
+                  <remarks>
+                     <p>The current allowed values are based on those identified in <a
+                           href="https://doi.org/10.6028/NIST.SP.800-60v2r1">NIST SP 800-60 Volume
+                           2</a>
+                     </p>
+                  </remarks>
+               </define-field>
+               <!--<field ref="property" max-occurs="unbounded">
+            <use-name>prop</use-name>
+            <group-as name="properties" in-json="ARRAY"/>
+         </field>-->
+               <!-- <assembly ref="annotation" max-occurs="unbounded">
+            <group-as name="annotations" in-json="ARRAY"/>
+         </assembly>-->
+               <!--<assembly ref="link" max-occurs="unbounded">
+            <group-as name="links" in-json="ARRAY"/>
+         </assembly>-->
+               <define-assembly name="confidentiality-impact" min-occurs="1">
+                  <formal-name>Confidentiality Impact Level</formal-name>
+                  <description>The expected level of impact resulting from the unauthorized
+                     disclosure of information.</description>
+                  <model>
+                     <!--<field ref="property" max-occurs="unbounded">
+                  <use-name>prop</use-name>
+                  <group-as name="properties" in-json="ARRAY"/>
+               </field>
+               <assembly ref="annotation" max-occurs="unbounded">
+                  <group-as name="annotations" in-json="ARRAY"/>
+               </assembly>
+               <assembly ref="link" max-occurs="unbounded">
+                  <group-as name="links" in-json="ARRAY"/>
+               </assembly>-->
+                     <field ref="base"/>
+                     <field ref="selected"/>
+
+                  </model>
+               </define-assembly>
+               <define-assembly name="integrity-impact" min-occurs="1">
+                  <formal-name>Integrity Impact Level</formal-name>
+                  <description>The expected level of impact resulting from the unauthorized
+                     modification of information.</description>
+                  <model>
+                     <!--<field ref="property" max-occurs="unbounded">
+                  <use-name>prop</use-name>
+                  <group-as name="properties" in-json="ARRAY"/>
+               </field>
+               <assembly ref="annotation" max-occurs="unbounded">
+                  <group-as name="annotations" in-json="ARRAY"/>
+               </assembly>
+               <assembly ref="link" max-occurs="unbounded">
+                  <group-as name="links" in-json="ARRAY"/>
+               </assembly>-->
+                     <field ref="base"/>
+                     <field ref="selected"/>
+
+                  </model>
+               </define-assembly>
+               <define-assembly name="availability-impact" min-occurs="1">
+                  <formal-name>Availability Impact Level</formal-name>
+                  <description>The expected level of impact resulting from the disruption of access
+                     to or use of information or the information system.</description>
+                  <model>
+                     <!--<field ref="property" max-occurs="unbounded">
+                  <use-name>prop</use-name>
+                  <group-as name="properties" in-json="ARRAY"/>
+               </field>
+               <assembly ref="annotation" max-occurs="unbounded">
+                  <group-as name="annotations" in-json="ARRAY"/>
+               </assembly>
+               <assembly ref="link" max-occurs="unbounded">
+                  <group-as name="links" in-json="ARRAY"/>
+               </assembly>-->
+                     <field ref="base"/>
+                     <field ref="selected"/>
+
+                  </model>
+               </define-assembly>
+            </model>
+         </define-assembly>
+      </model>
+   </define-assembly>
+   <define-field name="base" as-type="string" scope="local">
+      <formal-name>Base Level (Confidentiality, Integrity, or Availability)</formal-name>
+      <description>The prescribed base (Confidentiality, Integrity, or Availability) security impact
+         level.</description>
+   </define-field>
+   <define-field name="selected" as-type="string" scope="local">
+      <formal-name>Selected Level (Confidentiality, Integrity, or Availability)</formal-name>
+      <description>The selected (Confidentiality, Integrity, or Availability) security impact
+         level.</description>
+   </define-field>
+</METASCHEMA>

--- a/test-suite/schema-generation/group-as/group-as-misc_xml-schema.xsd
+++ b/test-suite/schema-generation/group-as/group-as-misc_xml-schema.xsd
@@ -1,0 +1,491 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+           xmlns:metaschema-group-as="http://csrc.nist.gov/ns/metaschema/unit-test/group-as-by-key"
+           xmlns:oscal-prose="http://csrc.nist.gov/ns/metaschema/unit-test/group-as-by-key"
+           elementFormDefault="qualified"
+           targetNamespace="http://csrc.nist.gov/ns/metaschema/unit-test/group-as-by-key"
+           version="1.0-milestone1">
+   <xs:annotation>
+      <xs:appinfo>
+         <m:schema-name>Metaschema Unit Test: group-as</m:schema-name>
+         <m:schema-version>1.0-milestone1</m:schema-version>
+         <m:short-name>metaschema-group-as</m:short-name>
+         <m:root>root</m:root>
+      </xs:appinfo>
+   </xs:annotation>
+   <xs:element name="root" type="metaschema-group-as:root-ASSEMBLY"/>
+   <xs:complexType name="root-ASSEMBLY">
+      <xs:annotation>
+         <xs:appinfo>
+            <m:formal-name>Root</m:formal-name>
+            <m:description>...</m:description>
+         </xs:appinfo>
+         <xs:documentation>
+            <b>Root</b>: ...</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="information-type" minOccurs="1" maxOccurs="unbounded">
+            <xs:complexType>
+               <xs:annotation>
+                  <xs:appinfo>
+                     <m:formal-name>Information Type</m:formal-name>
+                     <m:description>Contains details about one information type that is stored, processed, or transmitted by the system, such as privacy information, and those defined in <m:a>NIST SP 800-60</m:a>.</m:description>
+                  </xs:appinfo>
+                  <xs:documentation>
+                     <b>Information Type</b>: Contains details about one information type that is stored, processed, or transmitted by the system, such as privacy information, and those defined in NIST SP 800-60.</xs:documentation>
+               </xs:annotation>
+               <xs:sequence>
+                  <xs:element name="title" minOccurs="1" maxOccurs="1">
+                     <xs:complexType mixed="true">
+                        <xs:group ref="metaschema-group-as:everything-inline"/>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="description" minOccurs="1" maxOccurs="1">
+                     <xs:complexType mixed="true">
+                        <xs:group ref="metaschema-group-as:PROSE"/>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="information-type-id" minOccurs="0" maxOccurs="unbounded">
+                     <xs:complexType>
+                        <xs:annotation>
+                           <xs:appinfo>
+                              <m:formal-name>Information Type Identifier</m:formal-name>
+                              <m:description>An identifier qualified by the given identification <m:code>system</m:code> used, such as NIST SP 800-60.</m:description>
+                           </xs:appinfo>
+                           <xs:documentation>
+                              <b>Information Type Identifier</b>: An identifier qualified by the given identification system used, such as NIST SP 800-60.</xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleContent>
+                           <xs:extension base="xs:string">
+                              <xs:attribute name="system" use="required">
+                                 <xs:annotation>
+                                    <xs:appinfo>
+                                       <m:formal-name>Information Type Identification System</m:formal-name>
+                                       <m:description>Specifies the information type identification system used.</m:description>
+                                    </xs:appinfo>
+                                    <xs:documentation>
+                                       <b>Information Type Identification System</b>: Specifies the information type identification system used.</xs:documentation>
+                                 </xs:annotation>
+                                 <xs:simpleType>
+                                    <xs:union memberTypes="xs:string">
+                                       <xs:simpleType>
+                                          <xs:restriction base="xs:string">
+                                             <xs:enumeration value="https://doi.org/10.6028/NIST.SP.800-60v2r1">
+                                                <xs:annotation>
+                                                   <xs:documentation>
+                                                      <p>Based on the
+                              section identifiers in NIST Special Publication 800-60 Volume II
+                              Revision 1</p>
+                                                   </xs:documentation>
+                                                </xs:annotation>
+                                             </xs:enumeration>
+                                          </xs:restriction>
+                                       </xs:simpleType>
+                                    </xs:union>
+                                 </xs:simpleType>
+                              </xs:attribute>
+                           </xs:extension>
+                        </xs:simpleContent>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="confidentiality-impact" minOccurs="1" maxOccurs="1">
+                     <xs:complexType>
+                        <xs:annotation>
+                           <xs:appinfo>
+                              <m:formal-name>Confidentiality Impact Level</m:formal-name>
+                              <m:description>The expected level of impact resulting from the unauthorized disclosure of information.</m:description>
+                           </xs:appinfo>
+                           <xs:documentation>
+                              <b>Confidentiality Impact Level</b>: The expected level of impact resulting from the unauthorized disclosure of information.</xs:documentation>
+                        </xs:annotation>
+                        <xs:sequence>
+                           <xs:element name="base" minOccurs="0" maxOccurs="1">
+                              <xs:complexType>
+                                 <xs:annotation>
+                                    <xs:appinfo>
+                                       <m:formal-name>Base Level (Confidentiality, Integrity, or Availability)</m:formal-name>
+                                       <m:description>The prescribed base (Confidentiality, Integrity, or Availability) security impact level.</m:description>
+                                    </xs:appinfo>
+                                    <xs:documentation>
+                                       <b>Base Level (Confidentiality, Integrity, or Availability)</b>: The prescribed base (Confidentiality, Integrity, or Availability) security impact level.</xs:documentation>
+                                 </xs:annotation>
+                                 <xs:simpleContent>
+                                    <xs:extension base="xs:string"/>
+                                 </xs:simpleContent>
+                              </xs:complexType>
+                           </xs:element>
+                           <xs:element name="selected" minOccurs="0" maxOccurs="1">
+                              <xs:complexType>
+                                 <xs:annotation>
+                                    <xs:appinfo>
+                                       <m:formal-name>Selected Level (Confidentiality, Integrity, or Availability)</m:formal-name>
+                                       <m:description>The selected (Confidentiality, Integrity, or Availability) security impact level.</m:description>
+                                    </xs:appinfo>
+                                    <xs:documentation>
+                                       <b>Selected Level (Confidentiality, Integrity, or Availability)</b>: The selected (Confidentiality, Integrity, or Availability) security impact level.</xs:documentation>
+                                 </xs:annotation>
+                                 <xs:simpleContent>
+                                    <xs:extension base="xs:string"/>
+                                 </xs:simpleContent>
+                              </xs:complexType>
+                           </xs:element>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="integrity-impact" minOccurs="1" maxOccurs="1">
+                     <xs:complexType>
+                        <xs:annotation>
+                           <xs:appinfo>
+                              <m:formal-name>Integrity Impact Level</m:formal-name>
+                              <m:description>The expected level of impact resulting from the unauthorized modification of information.</m:description>
+                           </xs:appinfo>
+                           <xs:documentation>
+                              <b>Integrity Impact Level</b>: The expected level of impact resulting from the unauthorized modification of information.</xs:documentation>
+                        </xs:annotation>
+                        <xs:sequence>
+                           <xs:element name="base" minOccurs="0" maxOccurs="1">
+                              <xs:complexType>
+                                 <xs:annotation>
+                                    <xs:appinfo>
+                                       <m:formal-name>Base Level (Confidentiality, Integrity, or Availability)</m:formal-name>
+                                       <m:description>The prescribed base (Confidentiality, Integrity, or Availability) security impact level.</m:description>
+                                    </xs:appinfo>
+                                    <xs:documentation>
+                                       <b>Base Level (Confidentiality, Integrity, or Availability)</b>: The prescribed base (Confidentiality, Integrity, or Availability) security impact level.</xs:documentation>
+                                 </xs:annotation>
+                                 <xs:simpleContent>
+                                    <xs:extension base="xs:string"/>
+                                 </xs:simpleContent>
+                              </xs:complexType>
+                           </xs:element>
+                           <xs:element name="selected" minOccurs="0" maxOccurs="1">
+                              <xs:complexType>
+                                 <xs:annotation>
+                                    <xs:appinfo>
+                                       <m:formal-name>Selected Level (Confidentiality, Integrity, or Availability)</m:formal-name>
+                                       <m:description>The selected (Confidentiality, Integrity, or Availability) security impact level.</m:description>
+                                    </xs:appinfo>
+                                    <xs:documentation>
+                                       <b>Selected Level (Confidentiality, Integrity, or Availability)</b>: The selected (Confidentiality, Integrity, or Availability) security impact level.</xs:documentation>
+                                 </xs:annotation>
+                                 <xs:simpleContent>
+                                    <xs:extension base="xs:string"/>
+                                 </xs:simpleContent>
+                              </xs:complexType>
+                           </xs:element>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+                  <xs:element name="availability-impact" minOccurs="1" maxOccurs="1">
+                     <xs:complexType>
+                        <xs:annotation>
+                           <xs:appinfo>
+                              <m:formal-name>Availability Impact Level</m:formal-name>
+                              <m:description>The expected level of impact resulting from the disruption of access to or use of information or the information system.</m:description>
+                           </xs:appinfo>
+                           <xs:documentation>
+                              <b>Availability Impact Level</b>: The expected level of impact resulting from the disruption of access to or use of information or the information system.</xs:documentation>
+                        </xs:annotation>
+                        <xs:sequence>
+                           <xs:element name="base" minOccurs="0" maxOccurs="1">
+                              <xs:complexType>
+                                 <xs:annotation>
+                                    <xs:appinfo>
+                                       <m:formal-name>Base Level (Confidentiality, Integrity, or Availability)</m:formal-name>
+                                       <m:description>The prescribed base (Confidentiality, Integrity, or Availability) security impact level.</m:description>
+                                    </xs:appinfo>
+                                    <xs:documentation>
+                                       <b>Base Level (Confidentiality, Integrity, or Availability)</b>: The prescribed base (Confidentiality, Integrity, or Availability) security impact level.</xs:documentation>
+                                 </xs:annotation>
+                                 <xs:simpleContent>
+                                    <xs:extension base="xs:string"/>
+                                 </xs:simpleContent>
+                              </xs:complexType>
+                           </xs:element>
+                           <xs:element name="selected" minOccurs="0" maxOccurs="1">
+                              <xs:complexType>
+                                 <xs:annotation>
+                                    <xs:appinfo>
+                                       <m:formal-name>Selected Level (Confidentiality, Integrity, or Availability)</m:formal-name>
+                                       <m:description>The selected (Confidentiality, Integrity, or Availability) security impact level.</m:description>
+                                    </xs:appinfo>
+                                    <xs:documentation>
+                                       <b>Selected Level (Confidentiality, Integrity, or Availability)</b>: The selected (Confidentiality, Integrity, or Availability) security impact level.</xs:documentation>
+                                 </xs:annotation>
+                                 <xs:simpleContent>
+                                    <xs:extension base="xs:string"/>
+                                 </xs:simpleContent>
+                              </xs:complexType>
+                           </xs:element>
+                        </xs:sequence>
+                     </xs:complexType>
+                  </xs:element>
+               </xs:sequence>
+               <xs:attribute name="uuid" type="metaschema-group-as:uuid">
+                  <xs:annotation>
+                     <xs:appinfo>
+                        <m:formal-name>Information Type Universally Unique Identifier</m:formal-name>
+                        <m:description>A globally unique identifier that can be used to reference this information type entry elsewhere in an OSCAL document. A UUID should be consistantly used for a given resource across revisions of the document.</m:description>
+                     </xs:appinfo>
+                     <xs:documentation>
+                        <b>Information Type Universally Unique Identifier</b>: A globally unique identifier that can be used to reference this information type entry elsewhere in an OSCAL document. A UUID should be consistantly used for a given resource across revisions of the document.</xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:group name="PROSE">
+      <xs:choice>
+         <xs:element ref="oscal-prose:h1"/>
+         <xs:element ref="oscal-prose:h2"/>
+         <xs:element ref="oscal-prose:h3"/>
+         <xs:element ref="oscal-prose:h4"/>
+         <xs:element ref="oscal-prose:h5"/>
+         <xs:element ref="oscal-prose:h6"/>
+         <xs:element ref="oscal-prose:p"/>
+         <xs:element ref="oscal-prose:ul"/>
+         <xs:element ref="oscal-prose:ol"/>
+         <xs:element ref="oscal-prose:pre"/>
+         <xs:element ref="oscal-prose:table"/>
+      </xs:choice>
+   </xs:group>
+   <xs:element name="h1">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h2">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h3">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h4">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h5">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="h6">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:inlines"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="p">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:everything-inline"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="pre">
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="oscal-prose:mix"/>
+            <xs:element ref="oscal-prose:a"/>
+         </xs:choice>
+         <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="ol">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="oscal-prose:li"/>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="li">
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="oscal-prose:everything-inline"/>
+            <xs:element ref="oscal-prose:ol"/>
+            <xs:element ref="oscal-prose:ul"/>
+         </xs:choice>
+         <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="ul">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="oscal-prose:li"/>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="table">
+      <xs:complexType>
+         <xs:sequence>
+            <xs:element maxOccurs="unbounded" ref="oscal-prose:tr"/>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="tr">
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element maxOccurs="unbounded" ref="oscal-prose:td"/>
+            <xs:element maxOccurs="unbounded" ref="oscal-prose:th"/>
+         </xs:choice>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="th">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:everything-inline"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="td">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:everything-inline"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="everything-inline">
+      <xs:sequence>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="oscal-prose:mix"/>
+            <xs:group ref="oscal-prose:special"/>
+            <xs:element ref="oscal-prose:a"/>
+         </xs:choice>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="mix">
+      <xs:sequence>
+         <xs:group minOccurs="0" maxOccurs="unbounded" ref="oscal-prose:inlines"/>
+      </xs:sequence>
+   </xs:group>
+   <xs:group name="inlines">
+      <xs:sequence>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="oscal-prose:q"/>
+            <xs:element ref="oscal-prose:code"/>
+            <xs:element ref="oscal-prose:em"/>
+            <xs:element ref="oscal-prose:i"/>
+            <xs:element ref="oscal-prose:strong"/>
+            <xs:element ref="oscal-prose:b"/>
+            <xs:element ref="oscal-prose:sub"/>
+            <xs:element ref="oscal-prose:sup"/>
+            <xs:element ref="oscal-prose:img"/>
+         </xs:choice>
+      </xs:sequence>
+   </xs:group>
+   <xs:element name="q">
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="oscal-prose:code"/>
+            <xs:element ref="oscal-prose:em"/>
+            <xs:element ref="oscal-prose:i"/>
+            <xs:element ref="oscal-prose:b"/>
+            <xs:element ref="oscal-prose:strong"/>
+            <xs:element ref="oscal-prose:sub"/>
+            <xs:element ref="oscal-prose:sup"/>
+         </xs:choice>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="code">
+      <xs:complexType mixed="true">
+         <xs:group ref="oscal-prose:mix"/>
+         <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="strong">
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="oscal-prose:mix"/>
+            <xs:element ref="oscal-prose:a"/>
+         </xs:choice>
+         <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="em">
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="oscal-prose:mix"/>
+            <xs:element ref="oscal-prose:a"/>
+         </xs:choice>
+         <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="i">
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="oscal-prose:mix"/>
+            <xs:element ref="oscal-prose:a"/>
+         </xs:choice>
+         <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="b">
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:group ref="oscal-prose:mix"/>
+            <xs:element ref="oscal-prose:a"/>
+         </xs:choice>
+         <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="sub">
+      <xs:complexType mixed="true">
+         <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="sup">
+      <xs:complexType mixed="true">
+         <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="img">
+      <xs:complexType>
+         <xs:attribute name="alt"/>
+         <xs:attribute name="src" use="required" type="xs:anyURI"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:element name="a">
+      <xs:complexType mixed="true">
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="oscal-prose:q"/>
+            <xs:element ref="oscal-prose:code"/>
+            <xs:element name="em">
+               <xs:complexType mixed="true">
+                  <xs:attributeGroup ref="oscal-prose:optionalClass"/>
+               </xs:complexType>
+            </xs:element>
+         </xs:choice>
+         <xs:attribute name="href"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:group name="special">
+      <xs:sequence>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="oscal-prose:insert"/>
+         </xs:choice>
+      </xs:sequence>
+   </xs:group>
+   <xs:element name="insert">
+      <xs:complexType>
+         <xs:attribute name="param-id" use="required" type="xs:NCName"/>
+      </xs:complexType>
+   </xs:element>
+   <xs:attributeGroup name="requiredClass"/>
+   <xs:attributeGroup name="optionalClass"/>
+   <xs:attributeGroup name="hrefAttr">
+      <xs:attribute name="href"/>
+   </xs:attributeGroup>
+   <xs:simpleType name="uuid">
+      <xs:annotation>
+         <xs:documentation>A Type 4 ('random' or 'pseudorandom' UUID per RFC 4122</xs:documentation>
+      </xs:annotation>
+      <xs:restriction base="xs:string">
+         <xs:whiteSpace value="collapse"/>
+         <xs:pattern value="[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}">
+            <xs:annotation>
+               <xs:documentation>A sequence of 8-4-4-4-12 hex digits, with extra constraints in the 13th and 17-18th places for version 4</xs:documentation>
+            </xs:annotation>
+         </xs:pattern>
+      </xs:restriction>
+   </xs:simpleType>
+</xs:schema>

--- a/test-suite/schema-generation/local-declarations/modular_xml-schema.xsd
+++ b/test-suite/schema-generation/local-declarations/modular_xml-schema.xsd
@@ -31,10 +31,21 @@
                      type="oscal-catalog:module-global-field-FIELD"
                      minOccurs="0"
                      maxOccurs="1"/>
-         <xs:element name="module-top-level-local-field"
-                     type="oscal-catalog:module-top-level-local-field-FIELD"
-                     minOccurs="0"
-                     maxOccurs="1"/>
+         <xs:element name="module-top-level-local-field" minOccurs="0" maxOccurs="1">
+            <xs:complexType>
+               <xs:annotation>
+                  <xs:appinfo>
+                     <m:formal-name>Field, defined in a module as 'local'</m:formal-name>
+                     <m:description>XXX</m:description>
+                  </xs:appinfo>
+                  <xs:documentation>
+                     <b>Field, defined in a module as 'local'</b>: XXX</xs:documentation>
+               </xs:annotation>
+               <xs:simpleContent>
+                  <xs:extension base="xs:string"/>
+               </xs:simpleContent>
+            </xs:complexType>
+         </xs:element>
          <xs:element name="module-local-field" minOccurs="0" maxOccurs="1">
             <xs:complexType>
                <xs:annotation>
@@ -75,19 +86,6 @@
          <xs:extension base="xs:string"/>
       </xs:simpleContent>
    </xs:complexType>
-   <xs:complexType name="module-top-level-local-field-FIELD">
-      <xs:annotation>
-         <xs:appinfo>
-            <m:formal-name>Field, defined in a module as 'local'</m:formal-name>
-            <m:description>XXX</m:description>
-         </xs:appinfo>
-         <xs:documentation>
-            <b>Field, defined in a module as 'local'</b>: XXX</xs:documentation>
-      </xs:annotation>
-      <xs:simpleContent>
-         <xs:extension base="xs:string"/>
-      </xs:simpleContent>
-   </xs:complexType>
    <xs:element name="root-assembly" type="oscal-catalog:root-ASSEMBLY"/>
    <xs:complexType name="root-ASSEMBLY">
       <xs:annotation>
@@ -103,10 +101,21 @@
                      type="oscal-catalog:top-level-global-field-FIELD"
                      minOccurs="0"
                      maxOccurs="1"/>
-         <xs:element name="top-level-local-field"
-                     type="oscal-catalog:top-level-local-field-FIELD"
-                     minOccurs="0"
-                     maxOccurs="1"/>
+         <xs:element name="top-level-local-field" minOccurs="0" maxOccurs="1">
+            <xs:complexType>
+               <xs:annotation>
+                  <xs:appinfo>
+                     <m:formal-name>Field, defined at top level as 'local'</m:formal-name>
+                     <m:description>XXX</m:description>
+                  </xs:appinfo>
+                  <xs:documentation>
+                     <b>Field, defined at top level as 'local'</b>: XXX</xs:documentation>
+               </xs:annotation>
+               <xs:simpleContent>
+                  <xs:extension base="xs:string"/>
+               </xs:simpleContent>
+            </xs:complexType>
+         </xs:element>
          <xs:element name="local-field" minOccurs="0" maxOccurs="1">
             <xs:complexType>
                <xs:annotation>
@@ -152,19 +161,6 @@
          </xs:appinfo>
          <xs:documentation>
             <b>Field, defined at top level (global by default)</b>: XXX</xs:documentation>
-      </xs:annotation>
-      <xs:simpleContent>
-         <xs:extension base="xs:string"/>
-      </xs:simpleContent>
-   </xs:complexType>
-   <xs:complexType name="top-level-local-field-FIELD">
-      <xs:annotation>
-         <xs:appinfo>
-            <m:formal-name>Field, defined at top level as 'local'</m:formal-name>
-            <m:description>XXX</m:description>
-         </xs:appinfo>
-         <xs:documentation>
-            <b>Field, defined at top level as 'local'</b>: XXX</xs:documentation>
       </xs:annotation>
       <xs:simpleContent>
          <xs:extension base="xs:string"/>

--- a/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
+++ b/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
@@ -453,7 +453,6 @@
             <map key="additionalProperties">
                 <array key="allOf">
                     <map>
-                        <string key="type">object</string>
                         <xsl:apply-templates select="." mode="definition-or-reference"/>
                     </map>
                     <map>
@@ -640,77 +639,77 @@
     <xsl:key name="datatypes-by-name" xpath-default-namespace="http://www.w3.org/2005/xpath-functions"
         match="map" use="@key"/>
     
-    <xsl:variable name="datatypes" expand-text="false">
+    <!--<xsl:variable name="datatypes" expand-text="false">
         <dummy/>
-    </xsl:variable>
+    </xsl:variable>-->
         
-    <!--<xsl:variable name="datatypesX" expand-text="false">
+    <xsl:variable name="datatypes" expand-text="false">
         <map key="decimal">
             <string key="type">number</string>
             <string key="pattern">^(\+|-)?([0-9]+(\.[0-9]*)?|\.[0-9]+)$</string>
         </map>
         <map key="date">
             <string key="type">string</string>
-            <!-\-<string key="format">date</string> JQ 'date' implementation does not permit time zone -\->
+            <!--<string key="format">date</string> JQ 'date' implementation does not permit time zone -->
             <string key="pattern">^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))(Z|[+-][0-9]{2}:[0-9]{2})?$</string>
         </map>
         <map key="dateTime">
             <string key="type">string</string>
-            <!-\-<string key="format">date-time</string> JQ 'date-time' implementation requires time zone -\->
+            <!--<string key="format">date-time</string> JQ 'date-time' implementation requires time zone -->
             <string key="pattern">^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})?$</string>
         </map>
         <map key="date-with-timezone">
             <string key="type">string</string>
-            <!-\-The xs:date with a required timezone.-\->
+            <!--The xs:date with a required timezone.-->
             <string key="pattern">^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))(Z|[+-][0-9]{2}:[0-9]{2})$</string>
         </map>
         <map key="dateTime-with-timezone">
             <string key="type">string</string>
             <string key="format">date-time</string>
-            <!-\-The xs:dateTime with a required timezone.-\->
+            <!--The xs:dateTime with a required timezone.-->
             <string key="pattern">^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$</string>
         </map>
         <map key="email">
             <string key="type">string</string>
             <string key="format">email</string>
-            <!-\-\-\->
+            <!---->
             <string key="pattern">^.+@.+</string>
         </map>
         <map key="ip-v4-address">
             <string key="type">string</string>
             <string key="format">ipv4</string>
-            <!-\-The ip-v4-address type specifies an IPv4 address in dot decimal notation.-\->
+            <!--The ip-v4-address type specifies an IPv4 address in dot decimal notation.-->
             <string key="pattern">^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$</string>
         </map>
         <map key="ip-v6-address">
             <string key="type">string</string>
             <string key="format">ipv6</string>
-            <!-\-The ip-v6-address type specifies an IPv6 address represented in 8 hextets separated by colons.This is based on the pattern provided here: https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses with some customizations.-\->
+            <!--The ip-v6-address type specifies an IPv6 address represented in 8 hextets separated by colons.This is based on the pattern provided here: https://stackoverflow.com/questions/53497/regular-expression-that-matches-valid-ipv6-addresses with some customizations.-->
             <string key="pattern">^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|[fF][eE]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::([fF]{4}(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3,3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3,3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]))$</string>
         </map>
         <map key="hostname">
             <string key="type">string</string>
             <string key="format">idn-hostname</string>
-            <!-\-\-\->
+            <!---->
             <string key="pattern">^.+$</string>
         </map>
         <map key="uri">
             <string key="type">string</string>
             <string key="format">uri</string>
-            <!-\-\-\->
+            <!---->
         </map>
         <map key="uri-reference">
             <string key="type">string</string>
             <string key="format">uri-reference</string>
-            <!-\-\-\->
+            <!---->
         </map>
         <map key="uuid">
-            <!-\- A Type 4 ('random' or 'pseudorandom' UUID per RFC 4122-\->
+            <!-- A Type 4 ('random' or 'pseudorandom' UUID per RFC 4122-->
             <string key="type">string</string>
-            <!-\- A sequence of 8-4-4-4-12 hex digits, with extra constraints in the 13th and 17-18th places for version 4-\->
+            <!-- A sequence of 8-4-4-4-12 hex digits, with extra constraints in the 13th and 17-18th places for version 4-->
             <string key="pattern">^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$</string>
         </map>
-        <!-\- Possibly add support for XSD types ID, IDREF, IDREFS, NCName, NMTOKENS ???        -\->
-    </xsl:variable>-->
+        <!-- Possibly add support for XSD types ID, IDREF, IDREFS, NCName, NMTOKENS ???        -->
+    </xsl:variable>
 
 </xsl:stylesheet>


### PR DESCRIPTION
# Committer Notes

Correction to exposed bug in JSON Schema production - unwanted and redundant `'type': 'object'` was being emitted in the JSON Schema.

Also, I found that a chunk of code producing datatype-related constraints in the JSON Schema was disabled (for debugging); since we need it I enabled it again.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass? **Let's discuss**

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
