### PR TITLE
Towards actual content conversion

### DIFF
--- a/toolchains/xslt-M4/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
+++ b/toolchains/xslt-M4/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
@@ -107,7 +107,7 @@
       <xsl:text>&#xA;</xsl:text>
       <xsl:comment> XML to JSON conversion: Supermodel serialization as JSON
         including markdown production </xsl:comment>
-      <xsl:apply-templates mode="package-converter" select="document('supermodel-to-json.xsl')/xsl:*/( xsl:variable | xsl:template )"/>
+      <xsl:apply-templates mode="package-converter" select="document('converter-gen/supermodel-to-json.xsl')/xsl:*/( xsl:variable | xsl:template )"/>
     </xsl:copy>
   </xsl:template>
  

--- a/toolchains/xslt-M4/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
+++ b/toolchains/xslt-M4/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
@@ -65,7 +65,8 @@
     <nm:transform version="3.0">compose/unfold-model-map.xsl</nm:transform>
     <nm:transform version="3.0">compose/reduce-map.xsl</nm:transform>
     
-    <!--<nm:transform version="3.0">produce-xml-converter.xsl</nm:transform>-->
+    <nm:transform version="3.0">converter-gen/produce-xml-converter.xsl</nm:transform>
+    
   </xsl:variable>
   
   <xsl:variable name="metaschema-source" select="/"/>

--- a/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
+++ b/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
@@ -116,17 +116,14 @@
       <string key="$id">#/definitions/{@name}</string>
     </xsl:template>
     
-    <xsl:template priority="100" match="METASCHEMA/define-assembly">
-        <map key="{ $composed-metaschema/*/short-name }-{ @name }">
+    
+    <xsl:template priority="100" match="METASCHEMA/define-assembly | METASCHEMA/define-field">
+        <!-- XXX add module identifier -->
+        <map key="{ @name }">
             <xsl:next-match/>
         </map>
     </xsl:template>
     
-    <xsl:template priority="100" match="METASCHEMA/define-field">
-        <map key="{ $composed-metaschema/*/short-name }-{ @name }">
-            <xsl:next-match/>
-        </map>
-    </xsl:template>
     
     <xsl:template match="define-assembly">
             <xsl:apply-templates select="formal-name, description"/>


### PR DESCRIPTION
Adding missing link in content converter generation pipeline (XML->JSON); JSON Schema gen tweakage

# Committer Notes

Repairs a bug preventing from the generation of the XML->JSON content converter, producing instead an intermediate file.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
