### PR TITLE
Improvements to bidirectional XML-JSON conversion

### DIFF
--- a/toolchains/xslt-M4/compose/unfold-model-map.xsl
+++ b/toolchains/xslt-M4/compose/unfold-model-map.xsl
@@ -14,6 +14,9 @@
     <!-- Moved up to new 'group' parent -->
     <xsl:template match="@group-json | @group-xml | @group-name"/>
     
+<!-- Removing from objects not to be keyed -->
+    <xsl:template match="*[exists(@group-name)][@group-json='ARRAY']/@key"/>
+    
     <xsl:template match="*[exists(@group-name)]">
         <group name="{@group-name}" in-xml="{ if (@group-xml='GROUPED') then 'SHOWN' else 'HIDDEN' }"
             max-occurs="1" min-occurs="{ if (@min-occurs='0') then '0' else '1'}">

--- a/toolchains/xslt-M4/converter-gen/markdown-to-supermodel-xml-converter.xsl
+++ b/toolchains/xslt-M4/converter-gen/markdown-to-supermodel-xml-converter.xsl
@@ -12,14 +12,14 @@
 
     <xsl:mode on-no-match="shallow-copy"/>
     
+    <!-- The templates are the same, but kept separate to enable calling them in separately. -->
     <xsl:template match="value[@as-type=('markup-line')]">
         <xsl:copy>
             <xsl:copy-of select="@*"/>
-            <xsl:value-of>
-                <xsl:call-template name="parse-markdown">
-                    <xsl:with-param name="markdown-str" select="string(.)"/>
-                </xsl:call-template>
-            </xsl:value-of>
+            <!-- if this is valid only a single p comes back but who can tell? -->
+            <xsl:call-template name="parse-markdown-line">
+                <xsl:with-param name="markdown-str" select="string(.)"/>
+            </xsl:call-template>
         </xsl:copy>
     </xsl:template>
     
@@ -72,6 +72,15 @@
     i.e. < and & to &lt; and &amp;
     (we can ignore quotes as long as our markup has no attributes only elements)
     -->
+    
+    
+    <xsl:template name="parse-markdown-line">
+        <xsl:param name="markdown-str" as="xs:string" required="yes"/>
+        <xsl:variable name="str-as-textnode">
+            <xsl:value-of select="string($markdown-str) => replace('\\n','&#xA;')"/>
+        </xsl:variable>
+        <xsl:apply-templates select="$str-as-textnode" mode="infer-inlines"/>
+    </xsl:template>
     
     <xsl:template name="parse-markdown">
         
@@ -385,7 +394,7 @@
             <img         alt="!\[{{$noclosebracket}}\]" src="\({{$nocloseparen}}\)"/>
             <insert param-id="\{{\{{{{$nws}}\}}\}}"/>
             
-            <a href="\[{{$nocloseparen}}\]">\(<text not="\)"/>\)</a>
+            <a href="\[{{$noclosebracket}}\]">\(<text not="\)"/>\)</a>
             <code>`<text/>`</code>
             <strong>
                 <em>\*\*\*<text/>\*\*\*</em>
@@ -477,7 +486,7 @@
     <xsl:variable name="line-example" xml:space="preserve"> { insertion } </xsl:variable>
     
      <xsl:variable name="examples" xml:space="preserve">
-        <p>**Markdown** and even " quoted text" and **more markdown**</p>
+        <p>**Markdown** and even " quoted text" and **more markdown** with a [good link](#abc) and a [(choppy link)](#s1.2)</p>
          <p>**See the FedRAMP Documents page under Key Cloud Service Provider (CSP) Documents> Vulnerability Scanning Requirements** ([https://www.FedRAMP.gov/documents/](https://www.FedRAMP.gov/documents/))</p>
          <p>**See the FedRAMP Documents page under Key Cloud Service Provider\n\t\t\t\t\t\t\t\t(CSP) Documents> Vulnerability Scanning Requirements** ([https://www.FedRAMP.gov/documents/](https://www.FedRAMP.gov/documents/))</p>
         <p>

--- a/toolchains/xslt-M4/converter-gen/markdown-to-supermodel-xml-converter.xsl
+++ b/toolchains/xslt-M4/converter-gen/markdown-to-supermodel-xml-converter.xsl
@@ -375,7 +375,7 @@
     
     
 
-    <xsl:variable name="tag-specification" as="element(tag-spec)"  xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0/supermodel">
+    <xsl:variable name="tag-specification" as="element()"  xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0/supermodel">
         <tag-spec>
             <!-- The XML notation represents the substitution by showing both delimiters and tags  -->
             <!-- Note that text contents are regex notation for matching so * must be \* -->

--- a/toolchains/xslt-M4/converter-gen/produce-xml-converter.xsl
+++ b/toolchains/xslt-M4/converter-gen/produce-xml-converter.xsl
@@ -203,8 +203,8 @@
         <xsl:value-of select="@gi"/>
     </xsl:template>
     
-    <!-- Matches local declarations (only) -->
-    <xsl:template match="*" mode="make-xml-match">
+    <!-- Matches local declarations (only), but callable for globals when needed -->
+    <xsl:template match="*" mode="make-xml-match" name="make-full-context-match">
         <xsl:value-of>
             <xsl:for-each
                 select="ancestor-or-self::*[@gi]">

--- a/toolchains/xslt-M4/converter-gen/supermodel-to-json.xsl
+++ b/toolchains/xslt-M4/converter-gen/supermodel-to-json.xsl
@@ -268,7 +268,7 @@
     
     <xsl:template mode="md" match="li">
         <string>
-            <xsl:for-each select="../ancestor::ul">
+            <xsl:for-each select="(../ancestor::ul | ../ancestor::ol)">
                 <xsl:text>&#32;&#32;</xsl:text>
             </xsl:for-each>
             <xsl:text>* </xsl:text>
@@ -279,7 +279,7 @@
     
     <xsl:template mode="md" match="ol/li">
         <string>
-            <xsl:for-each select="../ancestor::ol">
+            <xsl:for-each select="(../ancestor::ul | ../ancestor::ol)">
                 <xsl:text xml:space="preserve">&#32;&#32;</xsl:text>
             </xsl:for-each>
             <xsl:text>1. </xsl:text>

--- a/toolchains/xslt-M4/converter-gen/supermodel-to-json.xsl
+++ b/toolchains/xslt-M4/converter-gen/supermodel-to-json.xsl
@@ -159,7 +159,8 @@
         <!--<xsl:if test="exists($lines except $lines/self::*:string)">
             <xsl:message expand-text="true">{ ($lines except $lines/self::*:string) ! serialize(.) }</xsl:message>
         </xsl:if>-->
-        <xsl:value-of select="$lines/self::*" separator="&#xA;"/>
+        <!--<xsl:copy-of select="$lines"/>-->
+        <xsl:value-of select="$lines/self::* => string-join('&#xA;')"/>
     </xsl:template>
     
     <!--<xsl:template match="value[@as-type='markup-multiline']/*" mode="md" priority="100">
@@ -277,9 +278,8 @@
     <!-- Since XProc doesn't support character maps we do this in XSLT -   -->
     
     <xsl:template mode="md" match="ol/li">
-        <string/>
         <string>
-            <xsl:for-each select="../ancestor::ul">
+            <xsl:for-each select="../ancestor::ol">
                 <xsl:text xml:space="preserve">&#32;&#32;</xsl:text>
             </xsl:for-each>
             <xsl:text>1. </xsl:text>

--- a/toolchains/xslt-M4/converter-gen/supermodel-to-json.xsl
+++ b/toolchains/xslt-M4/converter-gen/supermodel-to-json.xsl
@@ -124,18 +124,18 @@
         </xsl:element>
     </xsl:template>
     
-    <xsl:template match="field[@in-json='SCALAR'][empty(@key)]/value" mode="write-json">
-        <!-- A value given on a scalar field with no key gets no key either -->
+    <!--<xsl:template match="field[@in-json='SCALAR'][empty(@key)]/value" mode="write-json">
+        <!-\- A value given on a scalar field with no key gets no key either -\->
         <xsl:element name="{@in-json}" namespace="http://www.w3.org/2005/xpath-functions">
             <xsl:apply-templates mode="#current"/>
         </xsl:element>
-    </xsl:template>
+    </xsl:template>-->
     
     <xsl:template match="value" mode="write-json">
         <xsl:variable name="key-flag-name" select="@key-flag"/>
         <xsl:element name="{(@in-json[matches(.,'\S')],'string')[1]}"
             namespace="http://www.w3.org/2005/xpath-functions">
-            <xsl:attribute name="key"
+            <xsl:copy-of
                 select="(../flag[@key=$key-flag-name],parent::field[@in-json = 'SCALAR']/@key, @key)[1]"/>
             <xsl:apply-templates select="." mode="cast-data"/>
         </xsl:element>
@@ -145,6 +145,21 @@
         <xsl:value-of select="."/>
     </xsl:template>
     
+    <!--<xsl:template match="value[@as-type='markup-line']" mode="write-json">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates select="." mode="cast-data"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="value[@as-type='markup-multiline']" mode="write-json">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates select="." mode="cast-data"/>
+        </xsl:copy>
+    </xsl:template>
+    -->
+    
     <xsl:template match="value[@as-type='markup-line']" mode="cast-data">
         <xsl:apply-templates mode="md"/>
     </xsl:template>
@@ -153,13 +168,6 @@
         <xsl:variable name="lines" as="node()*">
             <xsl:apply-templates select="*" mode="md"/>
         </xsl:variable>
-        <!--<xsl:variable name="lines" as="item()*">
-            <xsl:apply-templates select="*" mode="md"/>
-        </xsl:variable>-->
-        <!--<xsl:if test="exists($lines except $lines/self::*:string)">
-            <xsl:message expand-text="true">{ ($lines except $lines/self::*:string) ! serialize(.) }</xsl:message>
-        </xsl:if>-->
-        <!--<xsl:copy-of select="$lines"/>-->
         <xsl:value-of select="$lines/self::* => string-join('&#xA;')"/>
     </xsl:template>
     

--- a/toolchains/xslt-M4/init.sh
+++ b/toolchains/xslt-M4/init.sh
@@ -70,7 +70,7 @@ convert_content() {
     result=$(xsl_transform "$xslt_converter" "$source_file" "$output_file" 2>&1)
     cmd_exitcode=$?
   elif [ "$source_format" == "json" ] && [ "$target_format" == "xml" ]; then
-    result=$(xsl_transform "$xslt_converter" "" "$output_file" "-it" "json-file=${source_file}" 2>&1)
+    result=$(xsl_transform "$xslt_converter" "" "$output_file" "-it:from-json" "file=file://${source_file}" 2>&1)
     cmd_exitcode=$?
   else
     >&2 echo -e "${P_ERROR}Conversion from ${source_format^^} to ${target_format^^} is not supported.${P_END}"

--- a/toolchains/xslt-M4/lib/oscal-whitespace-fixup.xsl
+++ b/toolchains/xslt-M4/lib/oscal-whitespace-fixup.xsl
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/2005/xpath-functions/math"
+    xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    xpath-default-namespace="http://csrc.nist.gov/ns/oscal/1.0"
+    exclude-result-prefixes="xs math"
+    version="3.0">
+    
+    <!-- p pre code tr table td th list li br q img insert a strong em sub sup -->
+    
+    <xsl:output indent="yes"/>
+    
+    <xsl:strip-space elements="*"/>
+    
+    <xsl:preserve-space elements="p pre code td th list li br q img insert a strong em sub sup"/>
+    
+<!-- cleanup mode emits content with all whitespace stripped except schema-determined 'significant' ws
+     this includes whitespace normalization inside p and li (in prose contexts)
+    
+     reset mode rewrites OSCAL with new whitespace.
+     it can be run together with 'cleanup' for a simple filter
+     or either mode can be used at the start or end of a pipeline
+     
+    -->
+    
+    <xsl:mode on-no-match="shallow-copy"/>
+    
+    <xsl:template match="pre//text()">
+        <xsl:value-of select="."/>
+    </xsl:template>
+
+    <xsl:template match="p//text() | li//text() | td//text() | th//text()">
+        <xsl:value-of select="replace(.,'\s+',' ')"/>
+    </xsl:template>
+
+    <xsl:template priority="3" match="p/descendant::text()[last()] 
+        | li/descendant::text()[last()]
+        | td/descendant::text()[last()]
+        | th/descendant::text()[last()]">
+        <xsl:variable name="so-far">
+            <xsl:next-match/>
+        </xsl:variable>
+        <xsl:sequence select="replace($so-far,'\s+$','')"/>
+    </xsl:template>
+
+    <xsl:template priority="3" match="p/descendant::text()[1]
+        | li/descendant::text()[1]
+        | td/descendant::text()[1]
+        | th/descendant::text()[1]">
+        <xsl:variable name="so-far">
+            <xsl:next-match/>
+        </xsl:variable>
+        <xsl:sequence select="replace($so-far,'^\s+','')"/>
+    </xsl:template>
+    
+    
+    <!--<xsl:template priority="10" match="p//text()[m:first-text(.,ancestor::p[1])] [m:last-text(.,ancestor::p[1])]
+        | li//text()[m:first-text(.,ancestor::li[1])] [m:last-text(.,ancestor::li[1])]
+        | td//text()[m:first-text(.,ancestor::td[1])] [m:last-text(.,ancestor::td[1])]
+        | th//text()[m:first-text(.,ancestor::th[1])] [m:last-text(.,ancestor::th[1])]">
+        <xsl:value-of select="replace(.,'\s',' ') => replace('\s$','') => replace('^ ','')"/>
+    </xsl:template>-->
+    
+    <!--<xsl:template match="p//text()[m:first-text(.,ancestor::p[1])]
+        | li//text()[m:first-text(.,ancestor::li[1])]
+        | td//text()[m:first-text(.,ancestor::td[1])]
+        | th//text()[m:first-text(.,ancestor::th[1])]">
+        <xsl:value-of select="replace(.,'\s',' ') => replace('^\s','')"/>
+    </xsl:template>
+    
+    <xsl:template match="p//text()[m:last-text(.,ancestor::p[1])]
+        | li//text()[m:last-text(.,ancestor::li[1])]
+        | td//text()[m:last-text(.,ancestor::td[1])]
+        | th//text()[m:last-text(.,ancestor::th[1])]">
+        <xsl:value-of select="replace(.,'\s',' ') => replace('\s$','')"/>
+    </xsl:template>-->
+    
+    <xsl:function name="m:first-text" as="xs:boolean">
+        <xsl:param name="which" as="text()"/>
+        <xsl:param name="whose" as="element()"/>
+        <xsl:sequence select="$which is $whose/descendant::text()[1]"/>
+    </xsl:function>
+
+    <xsl:function name="m:last-text" as="xs:boolean">
+        <xsl:param name="which" as="text()"/>
+        <xsl:param name="whose" as="element()"/>
+        <xsl:sequence select="$which is $whose/descendant::text()[last()]"/>
+    </xsl:function>
+    
+</xsl:stylesheet>

--- a/toolchains/xslt-M4/lib/oscal-whitespace-fixup.xsl
+++ b/toolchains/xslt-M4/lib/oscal-whitespace-fixup.xsl
@@ -3,8 +3,9 @@
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:math="http://www.w3.org/2005/xpath-functions/math"
     xmlns:m="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
+    xmlns="http://csrc.nist.gov/ns/oscal/1.0"
     xpath-default-namespace="http://csrc.nist.gov/ns/oscal/1.0"
-    exclude-result-prefixes="xs math"
+    exclude-result-prefixes="#all"
     version="3.0">
     
     <!-- p pre code tr table td th list li br q img insert a strong em sub sup -->
@@ -23,6 +24,61 @@
      or either mode can be used at the start or end of a pipeline
      
     -->
+    
+    <xsl:template match="/comment()"/>
+    
+    
+    <xsl:template match="title | label | choice | text">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            
+            <xsl:apply-templates>
+                <xsl:with-param name="text-trim" tunnel="true" select="true()"/>
+            </xsl:apply-templates>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="text()">
+        <xsl:param name="text-trim" tunnel="true" select="false()"/>
+        <xsl:choose>
+            <xsl:when test="$text-trim">
+                <xsl:apply-templates select="." mode="trim"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="."/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+    
+    <xsl:template match="text()[exists(../*)]" mode="trim">
+        <xsl:value-of select="replace(.,'\s+',' ')"/>
+    </xsl:template>
+    
+    <xsl:template match="text()" mode="trim">
+        <xsl:value-of select="string(.) => normalize-space()"/>
+    </xsl:template>
+    
+    <xsl:template match="metadata">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:apply-templates select="title, published"/>
+            <!-- time stamp it at runtime -->
+            <last-modified xsl:expand-text="true">{ current-dateTime() }</last-modified>
+            <xsl:apply-templates select="* except (title | published)"/>
+        </xsl:copy>
+    </xsl:template>
+    
+    <xsl:template match="last-modified" priority="6"/>
+    
+    <xsl:template match="oscal-version" priority="6">
+        <oscal-version>1.0.0-rc1</oscal-version>
+    </xsl:template>
+    
+    <xsl:template match="i">
+        <em>
+            <xsl:apply-templates/>
+        </em>
+    </xsl:template>
     
     <xsl:mode on-no-match="shallow-copy"/>
     

--- a/toolchains/xslt-M4/lib/oscal-whitespace-fixup.xsl
+++ b/toolchains/xslt-M4/lib/oscal-whitespace-fixup.xsl
@@ -30,10 +30,6 @@
         <xsl:value-of select="."/>
     </xsl:template>
 
-    <xsl:template match="p//text() | li//text() | td//text() | th//text()">
-        <xsl:value-of select="replace(.,'\s+',' ')"/>
-    </xsl:template>
-
     <xsl:template priority="3" match="p/descendant::text()[last()] 
         | li/descendant::text()[last()]
         | td/descendant::text()[last()]
@@ -44,7 +40,7 @@
         <xsl:sequence select="replace($so-far,'\s+$','')"/>
     </xsl:template>
 
-    <xsl:template priority="3" match="p/descendant::text()[1]
+    <xsl:template priority="2" match="p/descendant::text()[1]
         | li/descendant::text()[1]
         | td/descendant::text()[1]
         | th/descendant::text()[1]">
@@ -54,7 +50,10 @@
         <xsl:sequence select="replace($so-far,'^\s+','')"/>
     </xsl:template>
     
-    
+    <xsl:template match="p//text() | li//text() | td//text() | th//text()">
+        <xsl:value-of select="replace(.,'\s+',' ')"/>
+    </xsl:template>
+
     <!--<xsl:template priority="10" match="p//text()[m:first-text(.,ancestor::p[1])] [m:last-text(.,ancestor::p[1])]
         | li//text()[m:first-text(.,ancestor::li[1])] [m:last-text(.,ancestor::li[1])]
         | td//text()[m:first-text(.,ancestor::td[1])] [m:last-text(.,ancestor::td[1])]

--- a/toolchains/xslt-M4/metapath/metapath-jsonize.xsl
+++ b/toolchains/xslt-M4/metapath/metapath-jsonize.xsl
@@ -60,6 +60,7 @@
         <!--<test>field-flagged-groupable</test>
         <test>field-dynamic-value-key</test>-->
         <!--<test>*/@color</test>-->
+        <test>catalog//group//part</test>
         <test>catalog//group//control/param/select/choice</test>
         <!--<test>catalog//control/title</test>-->
         <test>nowhere</test>

--- a/toolchains/xslt-M4/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
+++ b/toolchains/xslt-M4/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
@@ -170,7 +170,7 @@
       <XSLT:call-template name="from-xdm-json-xml">
         <XSLT:with-param name="source">
           <XSLT:try select="unparsed-text($file) ! json-to-xml(.)" xmlns:err="http://www.w3.org/2005/xqt-errors">
-            <XSLT:catch>
+            <XSLT:catch expand-text="true">
               <nm:ERROR code="{{ $err:code }}">{{ $err:description }}</nm:ERROR>
             </XSLT:catch>
           </XSLT:try>
@@ -187,7 +187,7 @@
           <xsl:comment> evaluate { $file } as URI (absolute or relative to stylesheet)</xsl:comment>
           <XSLT:when test="exists($file)">
             <XSLT:try select="document($file)" xmlns:err="http://www.w3.org/2005/xqt-errors">
-              <XSLT:catch>
+              <XSLT:catch expand-text="true">
                 <nm:ERROR code="{{ $err:code }}">{ $err:description }</nm:ERROR>
               </XSLT:catch>
             </XSLT:try>    

--- a/toolchains/xslt-M4/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
+++ b/toolchains/xslt-M4/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
@@ -154,6 +154,7 @@
   
   
   <xsl:variable name="transformation-architecture">
+    <XSLT:output indent="true"/>
     <xsl:text>&#xA;</xsl:text>
     <xsl:comment> Processing architecture </xsl:comment>
     <xsl:comment> $file should be a URI, absolute or relative to the XSLT transformation</xsl:comment>

--- a/toolchains/xslt-M4/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
+++ b/toolchains/xslt-M4/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
@@ -9,7 +9,7 @@
   version="3.0">
 
 
-    <xsl:output indent="yes"/>
+  <xsl:output indent="yes"/>
 
   <xsl:namespace-alias stylesheet-prefix="XSLT" result-prefix="xsl"/>
   
@@ -165,7 +165,7 @@
         </XSLT:when>
         <XSLT:otherwise>
           <XSLT:variable name="new-json-xml">
-            <XSLT:apply-templates select="$supermodel" mode="write-json"/>
+            <XSLT:apply-templates select="$supermodel/*" mode="write-json"/>
           </XSLT:variable>
             <XSLT:choose>
               <XSLT:when test="matches($produce,('xpath|xdm|xml'))">

--- a/toolchains/xslt-M4/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
+++ b/toolchains/xslt-M4/nist-metaschema-MAKE-XML-TO-JSON-CONVERTER.xsl
@@ -128,7 +128,9 @@
                 'supermodel' to produce supermodel intermediate -->
     <XSLT:param name="json-indent" as="xs:string">no</XSLT:param>
     
-    <XSLT:output omit-xml-declaration="true"/>
+    <xsl:comment> NB the output method is XML but serialized JSON is written with disable-output-escaping (below)
+     permitting inspection of intermediate results without changing the serialization method.</xsl:comment>
+    <XSLT:output omit-xml-declaration="true" method="xml"/>
     
     <XSLT:variable name="write-options" as="map(*)">
       <XSLT:map>
@@ -159,6 +161,7 @@
       <XSLT:variable name="supermodel">
         <XSLT:apply-templates select="$source/*"/>
       </XSLT:variable>
+      <XSLT:variable name="result">
       <XSLT:choose>
         <XSLT:when test="$produce = 'supermodel'">
           <XSLT:sequence select="$supermodel"/>
@@ -174,7 +177,7 @@
               <XSLT:otherwise>
                 <XSLT:try select="xml-to-json($new-json-xml, $write-options)"
                   xmlns:err="http://www.w3.org/2005/xqt-errors">
-                  <XSLT:catch>
+                  <XSLT:catch expand-text="true">
                     <nm:ERROR code="{{ $err:code }}">{ $err:description }</nm:ERROR>
                   </XSLT:catch>
                 </XSLT:try>
@@ -182,6 +185,11 @@
             </XSLT:choose>
         </XSLT:otherwise>
       </XSLT:choose>   
+      </XSLT:variable>
+      <XSLT:sequence select="$result/*"/>
+      <XSLT:if test="matches($result,'\S') and empty($result/*)">
+        <XSLT:value-of select="$result" disable-output-escaping="true"/>
+      </XSLT:if>
     </XSLT:template>
   </xsl:variable>
   

--- a/toolchains/xslt-M4/schema-gen/make-metaschema-xsd.xsl
+++ b/toolchains/xslt-M4/schema-gen/make-metaschema-xsd.xsl
@@ -243,7 +243,7 @@
     </xsl:template>
     
     <xsl:template priority="5" match="define-field[@as-type='markup-multiline']">
-            <xs:complexType mixed="true">
+            <xs:complexType>
                 <xsl:call-template name="name-global-field-type"/>
                 <xs:group ref="{$declaration-prefix}:PROSE" maxOccurs="unbounded" minOccurs="0"/>
                 <xsl:apply-templates select="define-flag | flag"/>

--- a/toolchains/xslt-M4/testing/test-xml-json-roundtrip.xpl
+++ b/toolchains/xslt-M4/testing/test-xml-json-roundtrip.xpl
@@ -58,7 +58,7 @@
     <p:pipe        port="result" step="convert-supermodel.1-to-xml"/>
   </p:output>
   
-  <p:serialization port="h_MIDWAY_supermodel.1-as-xpath-json" indent="false"/>
+  <p:serialization port="h_MIDWAY_supermodel.1-as-xpath-json" indent="true"/>
   <p:output        port="h_MIDWAY_supermodel.1-as-xpath-json" primary="false">
     <p:pipe        port="result"                step="convert-supermodel.1-to-json-xml"/>
   </p:output>
@@ -190,7 +190,7 @@
       </p:input>
     </p:xslt>
     
-    <!--<p:identity name="convert-markdown-to-markup"/>-->
+<!--    <p:identity name="convert-markdown-to-markup"/>-->
     <p:xslt name="convert-markdown-to-markup">
       <p:input port="stylesheet">
         <p:document href="../converter-gen/markdown-to-supermodel-xml-converter.xsl"/>

--- a/toolchains/xslt-M4/testing/test-xml-json-roundtrip.xpl
+++ b/toolchains/xslt-M4/testing/test-xml-json-roundtrip.xpl
@@ -190,7 +190,7 @@
       </p:input>
     </p:xslt>
     
-<!--    <p:identity name="convert-markdown-to-markup"/>-->
+    <!--<p:identity name="convert-markdown-to-markup"/>-->
     <p:xslt name="convert-markdown-to-markup">
       <p:input port="stylesheet">
         <p:document href="../converter-gen/markdown-to-supermodel-xml-converter.xsl"/>


### PR DESCRIPTION
# Committer Notes

Needed finishing touches to M4 framework support of bidirectional XML-JSON conversion including Markdown conversion.

Also an edit to the shell that calls the bidirectional converter script under CI, with the new interface.

At time of writing, these scripts still produce tracebacks now being diagnosed. Many or most appear to be whitespace-related issues, with an available remedy (a whitespace normalization filter on XML intake).

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
