### PR TITLE
Rc1 content integration dec2020d

### DIFF
--- a/toolchains/xslt-M4/converter-gen/markdown-to-supermodel-xml-converter.xsl
+++ b/toolchains/xslt-M4/converter-gen/markdown-to-supermodel-xml-converter.xsl
@@ -99,6 +99,7 @@
         <xsl:variable name="blocks">
             <xsl:for-each-group select="tokenize($str, '\n')"
                 group-starting-with=".[matches(., '^```')]">
+                <!-- odd groups are code if the first one has code, otherwise evens -->
                 <xsl:variable name="this-is-code" select="not((position() mod 2) + number($starts-with-code))"/>
                 <p><!-- Adding an attribute flag when this is a code block, code='code' -->
                     <xsl:if test="$this-is-code">
@@ -114,6 +115,7 @@
         <xsl:variable name="rough-blocks">
             <xsl:apply-templates select="$blocks" mode="parse-block"/>
         </xsl:variable>
+        <!-- for debugging <xsl:copy-of select="$rough-blocks"/> -->
         <xsl:variable name="flat-structures">
             <xsl:apply-templates select="$rough-blocks" mode="mark-structures"/>
         </xsl:variable>
@@ -142,12 +144,10 @@
     <!-- Matches blocks marked as code  -->
     <xsl:template mode="parse-block" priority="1" match="p[exists(@code)]" expand-text="true">
         <pre>
-            <code>
-                <xsl:for-each select="@code[not(.='code')]">
-                    <xsl:attribute name="class">language-{.}</xsl:attribute>
-                </xsl:for-each>
-                <xsl:value-of select="string(.)"/>
-            </code>
+            <xsl:for-each select="@code[not(.='code')]">
+                <xsl:attribute name="class">language-{.}</xsl:attribute>
+            </xsl:for-each>
+            <xsl:value-of select="string(.)"/>
         </pre>
     </xsl:template>
     
@@ -155,7 +155,8 @@
     <xsl:template mode="parse-block" match="p" expand-text="true">
         <xsl:for-each select="tokenize(string(.),'\n\s*\n')[normalize-space(.)]">
             <p>
-                <xsl:value-of select="replace(.,'^\s*\n','')"/>
+                <!-- trimming leading and trailing whitespace here -->
+                <xsl:value-of select="replace(.,'(^\s*\n|\s+$)','')"/>
             </p>
         </xsl:for-each>
     </xsl:template>
@@ -485,7 +486,13 @@
     
     <xsl:variable name="line-example" xml:space="preserve"> { insertion } </xsl:variable>
     
-     <xsl:variable name="examples" xml:space="preserve">
+     <xsl:variable name="examples"><p>Here is something to ponder:
+  
+```
+[code goes here]
+```
+        
+        </p> 
         <p>**Markdown** and even " quoted text" and **more markdown** with a [good link](#abc) and a [(choppy link)](#s1.2)</p>
          <p>**See the FedRAMP Documents page under Key Cloud Service Provider (CSP) Documents> Vulnerability Scanning Requirements** ([https://www.FedRAMP.gov/documents/](https://www.FedRAMP.gov/documents/))</p>
          <p>**See the FedRAMP Documents page under Key Cloud Service Provider\n\t\t\t\t\t\t\t\t(CSP) Documents> Vulnerability Scanning Requirements** ([https://www.FedRAMP.gov/documents/](https://www.FedRAMP.gov/documents/))</p>

--- a/toolchains/xslt-M4/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
+++ b/toolchains/xslt-M4/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
@@ -115,7 +115,7 @@
       <xsl:text>&#xA;</xsl:text>
       <xsl:comment> JSON to XML conversion: Markdown to markup inferencing </xsl:comment>
       
-      <xsl:apply-templates mode="package-converter" select="document('converter-gen/markdown-to-supermodel-xml-converter.xsl')/xsl:*/( xsl:* except xsl:output )"/>
+      <xsl:apply-templates mode="package-converter" select="document('converter-gen/markdown-to-supermodel-xml-converter.xsl')/xsl:*/( xsl:* except (xsl:output | xsl:mode) )"/>
       
       <xsl:text>&#xA;</xsl:text>
       <xsl:comment> JSON to XML conversion: Supermodel serialization as XML </xsl:comment>
@@ -217,6 +217,11 @@
         </XSLT:otherwise>
       </XSLT:choose>   
     </XSLT:template>
+    
+    <XSLT:template match="/j:map[empty(@key)]" priority="10">
+      <XSLT:apply-templates/>
+    </XSLT:template>
+    
   </xsl:variable>
   
 </xsl:stylesheet>


### PR DESCRIPTION
# Committer Notes

The generator now correctly emits SSP XML for SSP JSON.

Under testing in the usnistgov/oscal-content repository, everything runs, the only hiccups being some whitespace anomalies we will repair in the source.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
