### PR TITLE
Repair to (JSON) schema generation bug on module-local flag definition

### DIFF
--- a/toolchains/xslt-M4/compose/metaschema-collect.xsl
+++ b/toolchains/xslt-M4/compose/metaschema-collect.xsl
@@ -80,12 +80,28 @@
  <!-- Same at the other end - references to module-local definitions are relabeled correspondingly
       (to disambiguate from others of the same name in other modules) -->
     
-    <xsl:key name="top-level-local-definition-by-name" use="@name"
-        match="METASCHEMA/define-assembly[@scope='local'] |
-               METASCHEMA/define-field[@scope='local']    |
-               METASCHEMA/define-flag[@scope='local']" />
+    <xsl:key name="top-level-local-assembly-definition-by-name" use="@name"
+        match="METASCHEMA/define-assembly[@scope='local']" />
     
-    <xsl:template mode="acquire" match="model//*[exists( key('top-level-local-definition-by-name',@ref) )]">
+    <xsl:key name="top-level-local-field-definition-by-name" use="@name"
+        match="METASCHEMA/define-field[@scope='local']" />
+    
+    <xsl:key name="top-level-local-flag-definition-by-name" use="@name"
+        match="METASCHEMA/define-flag[@scope='local']" />
+    
+    <xsl:template mode="acquire" match="assembly[exists( key('top-level-local-assembly-definition-by-name',@ref) )]">
+        <xsl:call-template name="rewrite-local-reference"/>
+    </xsl:template>
+    
+    <xsl:template mode="acquire" match="field[exists( key('top-level-local-field-definition-by-name',@ref) )]">
+        <xsl:call-template name="rewrite-local-reference"/>
+    </xsl:template>
+    
+    <xsl:template mode="acquire" match="flag[exists( key('top-level-local-flag-definition-by-name',@ref) )]">
+        <xsl:call-template name="rewrite-local-reference"/>
+    </xsl:template>
+    
+    <xsl:template name="rewrite-local-reference">
         <xsl:copy>
             <xsl:copy-of select="@*"/>
             <xsl:attribute name="ref" expand-text="true">{ ancestor::METASCHEMA[1]/short-name }-{ @ref }</xsl:attribute>

--- a/toolchains/xslt-M4/metaschema-compose.xpl
+++ b/toolchains/xslt-M4/metaschema-compose.xpl
@@ -30,8 +30,8 @@
     <p:pipe port="result" step="reduce2"/>
   </p:output>
 
-  <p:serialization port="_3_digested" indent="true"/>
-  <p:output port="_3_digested" primary="false">
+  <p:serialization port="_4_digested" indent="true"/>
+  <p:output port="_4_digested" primary="false">
     <p:pipe port="result" step="digest"/>
   </p:output>
   

--- a/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
+++ b/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
@@ -116,8 +116,14 @@
         <xsl:text>#/definitions/{ $lineage => string-join('-') }</xsl:text>
     </xsl:template>
 
-    <xsl:template priority="100" match="METASCHEMA/define-assembly | METASCHEMA/define-field">
-        <map key="{ @name }">
+    <xsl:template priority="100" match="METASCHEMA/define-assembly">
+        <map key="{ $composed-metaschema/*/short-name }-{ @name }">
+            <xsl:next-match/>
+        </map>
+    </xsl:template>
+    
+    <xsl:template priority="100" match="METASCHEMA/define-field">
+        <map key="{ $composed-metaschema/*/short-name }-{ @name }">
             <xsl:next-match/>
         </map>
     </xsl:template>


### PR DESCRIPTION
# Committer Notes

Addresses the bug reported by @tcorsa on usnistgov/OSCAL#844.

PR #125 claims falsely to have remedied this bug, but it was a false report - test data in that branch does not expose it.

The problem was that the filter that collects and reconciles metaschema modules was failing to resolve fully (and rewrite) the links from flag invocations to their (local) definitions, leading to data lapse in subsequent phases. We had this working for assemblies and fields but not flags.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

n/a - no changes to core features
