### PR TITLE
added data types to use-name and cleaned up remarks

### DIFF
--- a/toolchains/xslt-M4/validate/metaschema.xsd
+++ b/toolchains/xslt-M4/validate/metaschema.xsd
@@ -26,7 +26,6 @@
           <xs:element name="define-flag" type="m:global-flag-definition"/>
         </xs:choice>
       </xs:sequence>
-      <xs:attribute name="module" type="xs:anyURI"/>
       <xs:attribute name="abstract">
         <xs:simpleType>
           <xs:restriction base="xs:string">
@@ -72,11 +71,10 @@
       </xs:choice>
       <xs:element name="model" minOccurs="0" type="m:assembly-model"/>
       <xs:element minOccurs="0" name="constraint" type="m:assembly-constraint-type"/>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:remarks"/>
+      <xs:element minOccurs="0" ref="m:remarks"/>
       <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:example"/>
     </xs:sequence>
     <xs:attribute name="name" use="required" type="xs:NCName"/>
-    <xs:attribute name="module" type="xs:anyURI"/>
     <xs:attribute name="scope" type="m:scope-type" default="global"/>
   </xs:complexType>
 
@@ -111,13 +109,12 @@
           type="m:local-flag-definition"/>
       </xs:choice>
       <xs:element minOccurs="0" name="constraint" type="m:model-constraint-type"/>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:remarks"/>
+      <xs:element minOccurs="0" ref="m:remarks"/>
       <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:example"/>
     </xs:sequence>
     <xs:attribute name="as-type" type="m:field-types" default="string"/>
     <xs:attribute name="collapsible" type="m:boolean" default="yes"/>
     <xs:attribute name="name" use="required" type="xs:NCName"/>
-    <xs:attribute name="module" type="xs:anyURI"/>
     <xs:attribute name="scope" type="m:scope-type" default="global"/>
   </xs:complexType>
 
@@ -133,14 +130,12 @@
       <xs:element minOccurs="0" ref="m:description"/>
       <xs:element minOccurs="0" name="use-name" type="xs:NCName"/>
       <xs:element name="constraint" minOccurs="0" type="m:define-flag-constraints-type"/>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:remarks"/>
+      <xs:element minOccurs="0" ref="m:remarks"/>
       <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:example"/>
     </xs:sequence>
     <xs:attribute name="name" use="required" type="xs:NCName"/>
     <!-- datatype should default to 'string' -->
     <xs:attribute name="as-type" type="m:simple-datatypes" default="string"/>
-    <!-- defined for composed (compiled) metaschemas -->
-    <xs:attribute name="module" type="xs:anyURI"/>
     <xs:attribute name="scope" type="m:scope-type" default="global"/>
   </xs:complexType>
 
@@ -153,7 +148,7 @@
     <xs:sequence>
       <xs:element minOccurs="0" ref="m:formal-name"/>
       <xs:element minOccurs="0" ref="m:description"/>
-      <xs:element minOccurs="0" name="use-name"/>
+      <xs:element minOccurs="0" name="use-name" type="xs:NCName"/>
       <xs:element minOccurs="0" maxOccurs="1" ref="m:json-key"/>
       <xs:element minOccurs="0" maxOccurs="1" ref="m:json-value-key"/>
       <xs:element minOccurs="0" ref="m:group-as"/>
@@ -164,13 +159,11 @@
       </xs:choice>
       <xs:element name="model" minOccurs="0" type="m:assembly-model"/>
       <xs:element minOccurs="0" name="constraint" type="m:assembly-constraint-type"/>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:remarks"/>
+      <xs:element minOccurs="0" ref="m:remarks"/>
       <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:example"/>
     </xs:sequence>
-    <xs:attribute name="collapsible" type="m:boolean" default="yes"/>
     <xs:attributeGroup ref="m:cardinality-specification"/>
     <xs:attribute name="name" use="required" type="xs:NCName"/>
-    <xs:attribute name="module" type="xs:anyURI"/>
   </xs:complexType>
 
 
@@ -183,7 +176,7 @@
     <xs:sequence>
       <xs:element minOccurs="0" ref="m:formal-name"/>
       <xs:element minOccurs="0" ref="m:description"/>
-      <xs:element minOccurs="0" name="use-name"/>
+      <xs:element minOccurs="0" name="use-name" type="xs:NCName"/>
       <xs:element minOccurs="0" maxOccurs="1" ref="m:json-key"/>
       <xs:element minOccurs="0" maxOccurs="1" ref="m:json-value-key"/>
       <xs:element minOccurs="0" ref="m:group-as"/>
@@ -193,14 +186,13 @@
           type="m:local-flag-definition"/>
       </xs:choice>
       <xs:element minOccurs="0" name="constraint" type="m:model-constraint-type"/>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:remarks"/>
+      <xs:element minOccurs="0" ref="m:remarks"/>
       <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:example"/>
     </xs:sequence>
     <xs:attribute name="as-type" type="m:field-types" default="string"/>
     <xs:attribute name="collapsible" type="m:boolean" default="yes"/>
     <xs:attributeGroup ref="m:cardinality-specification"/>
     <xs:attribute name="name" use="required" type="xs:NCName"/>
-    <xs:attribute name="module" type="xs:anyURI"/>
     <xs:attribute name="in-xml" default="WITH_WRAPPER">
       <xs:annotation>
         <xs:documentation>A field with assigned datatype 'markup-multiline' may be designated for representation with or without a containing (wrapper) element
@@ -232,15 +224,13 @@
       <xs:element minOccurs="0" ref="m:formal-name"/>
       <xs:element minOccurs="0" ref="m:description"/>
       <xs:element name="constraint" minOccurs="0" type="m:define-flag-constraints-type"/>
-      <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:remarks"/>
+      <xs:element minOccurs="0" ref="m:remarks"/>
       <xs:element minOccurs="0" maxOccurs="unbounded" ref="m:example"/>
     </xs:sequence>
     <xs:attribute name="name" use="required" type="xs:NCName"/>
     <!-- datatype should default to 'string' -->
     <xs:attribute name="as-type" type="m:simple-datatypes" default="string"/>
     <xs:attribute name="required" type="m:boolean" default="no"/>
-    <!-- defined for composed (compiled) metaschemas -->
-    <xs:attribute name="module" type="xs:anyURI"/>
   </xs:complexType>
 
   <xs:element name="formal-name" type="xs:string">
@@ -288,23 +278,11 @@
     </xs:annotation>
   </xs:element>
 
-  <xs:element name="remarks">
+  <xs:element name="remarks" type="m:markup-multiline">
     <xs:annotation>
       <xs:documentation>Any explanatory or helpful information to be provided in the
       documentation of an assembly, field or flag.</xs:documentation>
     </xs:annotation>
-    <xs:complexType>
-      <xs:complexContent>
-        <xs:extension base="m:markup-multiline">
-          <xs:attribute name="class" type="xs:NMTOKENS">
-            <xs:annotation>
-              <xs:documentation>Mark as 'XML' for XML-only or 'JSON' for JSON-only remarks.</xs:documentation>
-            </xs:annotation>
-          </xs:attribute>
-          <xs:attribute name="module" type="xs:anyURI"/>
-        </xs:extension>
-      </xs:complexContent>
-    </xs:complexType>
   </xs:element>
 
   <xs:complexType name="markup-multiline">
@@ -778,7 +756,6 @@
       </xs:sequence>
       <xs:attribute name="href" type="xs:anyURI"/>
       <xs:attribute name="path" type="xs:string"/>
-      <xs:attribute name="module" type="xs:anyURI"/>
     </xs:complexType>
   </xs:element>
 
@@ -858,8 +835,12 @@
         the field being defined. When a flag-name is provided, indicates that the value of the field
         is to be labeled in the JSON with the value of the flag.</xs:documentation>
     </xs:annotation>
-    <xs:complexType mixed="true">
-      <xs:attribute name="flag-name" type="xs:NCName"/>
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:NCName">
+          <xs:attribute name="flag-name" type="xs:NCName"/>
+        </xs:extension>
+      </xs:simpleContent>
     </xs:complexType>
   </xs:element>
 
@@ -907,7 +888,7 @@
 
   <!-- TODO: check if both forms are handled. In some cases only 'yes' is handled, and 'true' is not. -->
   <xs:simpleType name="boolean">
-    <xs:restriction base="xs:NCName">
+    <xs:restriction base="xs:string">
       <xs:enumeration value="yes"/>
       <xs:enumeration value="no"/>
     </xs:restriction>


### PR DESCRIPTION
# Committer Notes

Simplified remarks and removed module references, which are produced/used in compose.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
