### PR TITLE
Rectifying issues with recursive structures in conversion.

### DIFF
--- a/toolchains/xslt-M4/make-metaschema-converters.xpl
+++ b/toolchains/xslt-M4/make-metaschema-converters.xpl
@@ -3,63 +3,49 @@
   xmlns:c="http://www.w3.org/ns/xproc-step" version="1.0"
   xmlns:metaschema="http://csrc.nist.gov/ns/metaschema/1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  type="metaschema:make-xml-map" name="make-xml-map">
+  type="metaschema:make-metaschema-converters" name="make-metaschema-converters">
   
   <!-- &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& -->
   <!-- Ports -->
   
-  <p:input port="source" primary="true"/>
+  <p:input port="metaschema-source" primary="true"/>
+  
   <p:input port="parameters" kind="parameter"/>
   
-  <p:serialization port="a.echo-input" indent="true"/>
-  <p:output        port="a.echo-input" primary="false">
-    <p:pipe        port="result"       step="input"/>
+  <p:serialization port="a.composed-metaschema" indent="true"/>
+  <p:output        port="a.composed-metaschema" primary="false">
+    <p:pipe        port="result"       step="composed"/>
   </p:output>
   
-  <p:serialization port="b.composed" indent="true"/>
-  <p:output        port="b.composed" primary="false">
-    <p:pipe        port="result"     step="composed"/>
+  <p:serialization port="b.initial-model-map" indent="true"/>
+  <p:output        port="b.initial-model-map" primary="false">
+    <p:pipe        port="result"           step="make-model-map"/>
   </p:output>
   
-  <p:serialization port="c.abstract-model-map" indent="true"/>
-  <p:output        port="c.abstract-model-map" primary="false">
-    <p:pipe        port="result"               step="make-model-map"/>
+  <p:serialization port="c.unfolded-model-map" indent="true"/>
+  <p:output        port="c.unfolded-model-map" primary="false">
+    <p:pipe        port="result"           step="unfold-model-map"/>
   </p:output>
   
-  <p:serialization port="d.unfolded-model-map" indent="true"/>
-  <p:output        port="d.unfolded-model-map" primary="false">
-    <p:pipe        port="result"               step="unfold-model-map"/>
+  <p:serialization port="d.definition-model" indent="true"/>
+  <p:output        port="d.definition-model" primary="false">
+    <p:pipe        port="result"           step="definition-map"/>
   </p:output>
   
-  <p:serialization port="E.definition-map" indent="true"/>
-  <p:output        port="E.definition-map" primary="false">
-    <p:pipe        port="result"        step="definition-map"/>
+  <p:serialization port="E.xml-supermodel-converter" indent="true"/>
+  <p:output        port="E.xml-supermodel-converter" primary="false">
+    <p:pipe        port="result"               step="make-xml-converter"/>
   </p:output>
   
-  <p:serialization port="X1.xml-element-tree" indent="true"/>
-  <p:output        port="X1.xml-element-tree" primary="false">
-    <p:pipe        port="result"              step="make-xml-element-tree"/>
-  </p:output>
-  
-  <p:serialization port="X2.xml-model-html" indent="false" method="xml" omit-xml-declaration="false"/>
-  <p:output        port="X2.xml-model-html" primary="false">
-    <p:pipe        port="result"            step="render-xml-model-map"/>
-  </p:output>
-  
-  <p:serialization port="J1.json-object-tree" indent="true"/>
-  <p:output        port="J1.json-object-tree" primary="false">
-    <p:pipe        port="result"              step="make-json-object-tree"/>
-  </p:output>
-  
-  <p:serialization port="J2.json-model-html" indent="false" method="xml" omit-xml-declaration="false"/>
-  <p:output        port="J2.json-model-html" primary="false">
-    <p:pipe        port="result"             step="render-json-model-map"/>
+  <p:serialization port="E.json-supermodel-converter" indent="true"/>
+  <p:output        port="E.json-supermodel-converter" primary="false">
+    <p:pipe        port="result"               step="make-json-converter"/>
   </p:output>
   
   <!-- &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& -->
   <!-- Import (subpipeline) -->
   
-  <p:import href="metaschema-compose.xpl"/>
+  <p:import href="compose/metaschema-compose.xpl"/>
   
   <!-- &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& -->
   <!-- Pipeline -->
@@ -95,35 +81,22 @@
     </p:input>
   </p:xslt>
   
-  <p:sink/>
-  
   <p:xslt name="make-xml-converter">
-    <p:input port="source">
-      <p:pipe port="result" step="unfold-model-map"/>
-    </p:input>
     <p:input port="stylesheet">
-      <p:document href="document/xml/element-tree.xsl"/>
+      <p:document href="converter-gen/produce-xml-converter.xsl"/>
     </p:input>
   </p:xslt>
-  
-  
   
   <p:sink/>
   
-  <p:xslt name="make-json-object-tree">
+  <p:xslt name="make-json-converter">
     <p:input port="source">
-      <p:pipe port="result" step="unfold-model-map"/>
+      <p:pipe port="result" step="definition-map"/>
     </p:input>
     <p:input port="stylesheet">
-      <p:document href="document/json/object-tree.xsl"/>
+      <p:document href="converter-gen/produce-json-converter.xsl"/>
     </p:input>
   </p:xslt>
   
-  <p:xslt name="render-json-model-map">
-    <p:with-option name="initial-mode" select="QName('','make-page')"/>    
-    <p:input port="stylesheet">
-      <p:document href="document/json/object-map-html.xsl"/>
-    </p:input>
-  </p:xslt>
 
 </p:declare-step>

--- a/toolchains/xslt-M4/testing/models-testdata.xml
+++ b/toolchains/xslt-M4/testing/models-testdata.xml
@@ -33,6 +33,17 @@
     <h1>Unwrapped prose</h1>
     <p>Here we have unwrapped prose....</p>
     <p>And more and more unwrapped prose!</p>
+    
+    <branch1>
+        <OVERLOAD a="branch1-a">
+            <OVERLOAD a="branch1-a"/>
+        </OVERLOAD>
+    </branch1>
+    <branch2>
+        <OVERLOAD z="branch2-z">
+            <OVERLOAD z="branch2-z"/>
+        </OVERLOAD>
+    </branch2>
     <assembly-empty id="123"/>
     <assembly-empty-grouped id="456"/>
     <assembly-empty-grouped id="789"/>
@@ -42,8 +53,6 @@
             <field-1only>field</field-1only>
         </alias>
     </alias>
-    
-    
     <assembly-1only>
         <field-1only>ASSEMBLY-1-ONLY / FIELD-1-ONLY</field-1only>
     </assembly-1only>

--- a/toolchains/xslt-M4/testing/models_metaschema.xml
+++ b/toolchains/xslt-M4/testing/models_metaschema.xml
@@ -76,6 +76,8 @@
             <field ref="wrapped-prose" in-xml="WITH_WRAPPER"/>
             <field ref="loose-prose" in-xml="UNWRAPPED"/>
             
+            <assembly ref="branch1"/>
+            <assembly ref="branch2"/>
             <assembly ref="assembly-empty"/>
             <assembly ref="assembly-empty-grouped" max-occurs="unbounded">
                 <group-as name="empty-assembly-group"/>
@@ -188,6 +190,60 @@
         <formal-name>LOOSE-PROSE</formal-name>
         <description>field loose-prose</description>
     </define-field>
+    
+    <define-assembly name="branch1">
+        <formal-name>branch 1 for OVERLOAD1</formal-name>
+        <description>A discrete containter for objects with overloaded names.</description>
+        <model>
+            <assembly ref="overload1" max-occurs="unbounded">
+                <use-name>OVERLOAD</use-name>
+                <group-as name="OVERLOAD_GROUP" in-json="ARRAY"/>
+            </assembly>
+        </model>
+    </define-assembly>
+    
+    <define-assembly name="branch2">
+        <formal-name>branch 2 for OVERLOAD2</formal-name>
+        <description>A discrete containter for objects with overloaded names.</description>
+        <model>
+            <assembly ref="overload2" max-occurs="unbounded">
+                <use-name>OVERLOAD</use-name>
+                <group-as name="OVERLOAD_GROUP" in-json="ARRAY"/>
+            </assembly>
+        </model>
+    </define-assembly>
+    
+    <define-assembly name="overload1">
+        <formal-name>Overloaded name 1</formal-name>
+        <description>The first object with an overloaded name</description>
+        <use-name>OVERLOAD</use-name>
+        <define-flag name="a">
+            <formal-name>An OVERLOAD/@a</formal-name>
+            <description>A flag on an assembly called 'OVERLOAD'</description>
+        </define-flag>
+        <model>
+            <assembly ref="overload1" max-occurs="unbounded">
+                <use-name>OVERLOAD</use-name>
+                <group-as name="OVERLOAD_GROUP" in-json="ARRAY"/>
+            </assembly>
+        </model>
+    </define-assembly>
+    
+    <define-assembly name="overload2">
+        <formal-name>Overloaded name 2</formal-name>
+        <description>The second object with an overloaded name</description>
+        <use-name>OVERLOAD</use-name>
+        <define-flag name="z">
+            <formal-name>An OVERLOAD/@z</formal-name>
+            <description>A flag on an assembly called 'OVERLOAD'</description>
+        </define-flag>
+        <model>
+            <assembly ref="overload2" max-occurs="unbounded">
+                <use-name>OVERLOAD</use-name>
+                <group-as name="OVERLOAD_GROUP" in-json="ARRAY"/>
+            </assembly>
+        </model>
+    </define-assembly>
     
     <define-assembly name="assembly-empty">
         <formal-name>ASSEMBLY-EMPTY</formal-name>

--- a/toolchains/xslt-M4/testing/models_metaschema_XML-SCHEMA.xsd
+++ b/toolchains/xslt-M4/testing/models_metaschema_XML-SCHEMA.xsd
@@ -104,6 +104,14 @@
          <xs:group ref="everything:blockElementGroup"
                    maxOccurs="unbounded"
                    minOccurs="0"/>
+         <xs:element name="branch1"
+                     type="everything:everything-branch1-ASSEMBLY"
+                     minOccurs="0"
+                     maxOccurs="1"/>
+         <xs:element name="branch2"
+                     type="everything:everything-branch2-ASSEMBLY"
+                     minOccurs="0"
+                     maxOccurs="1"/>
          <xs:element name="assembly-empty"
                      type="everything:everything-assembly-empty-ASSEMBLY"
                      minOccurs="0"
@@ -443,6 +451,90 @@
       <xs:complexContent>
          <xs:extension base="everything:markupMultilineType"/>
       </xs:complexContent>
+   </xs:complexType>
+   <xs:complexType name="everything-branch1-ASSEMBLY">
+      <xs:annotation>
+         <xs:appinfo>
+            <m:formal-name>branch 1 for OVERLOAD1</m:formal-name>
+            <m:description>A discrete containter for objects with overloaded names.</m:description>
+         </xs:appinfo>
+         <xs:documentation>
+            <b>branch 1 for OVERLOAD1</b>: A discrete containter for objects with overloaded names.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="OVERLOAD"
+                     type="everything:everything-overload1-ASSEMBLY"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="everything-branch2-ASSEMBLY">
+      <xs:annotation>
+         <xs:appinfo>
+            <m:formal-name>branch 2 for OVERLOAD2</m:formal-name>
+            <m:description>A discrete containter for objects with overloaded names.</m:description>
+         </xs:appinfo>
+         <xs:documentation>
+            <b>branch 2 for OVERLOAD2</b>: A discrete containter for objects with overloaded names.</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="OVERLOAD"
+                     type="everything:everything-overload2-ASSEMBLY"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+      </xs:sequence>
+   </xs:complexType>
+   <xs:complexType name="everything-overload1-ASSEMBLY">
+      <xs:annotation>
+         <xs:appinfo>
+            <m:formal-name>Overloaded name 1</m:formal-name>
+            <m:description>The first object with an overloaded name</m:description>
+         </xs:appinfo>
+         <xs:documentation>
+            <b>Overloaded name 1</b>: The first object with an overloaded name</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="OVERLOAD"
+                     type="everything:everything-overload1-ASSEMBLY"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="a" type="everything:string">
+         <xs:annotation>
+            <xs:appinfo>
+               <m:formal-name>An OVERLOAD/@a</m:formal-name>
+               <m:description>A flag on an assembly called 'OVERLOAD'</m:description>
+            </xs:appinfo>
+            <xs:documentation>
+               <b>An OVERLOAD/@a</b>: A flag on an assembly called 'OVERLOAD'</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+   <xs:complexType name="everything-overload2-ASSEMBLY">
+      <xs:annotation>
+         <xs:appinfo>
+            <m:formal-name>Overloaded name 2</m:formal-name>
+            <m:description>The second object with an overloaded name</m:description>
+         </xs:appinfo>
+         <xs:documentation>
+            <b>Overloaded name 2</b>: The second object with an overloaded name</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="OVERLOAD"
+                     type="everything:everything-overload2-ASSEMBLY"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="z" type="everything:string">
+         <xs:annotation>
+            <xs:appinfo>
+               <m:formal-name>An OVERLOAD/@z</m:formal-name>
+               <m:description>A flag on an assembly called 'OVERLOAD'</m:description>
+            </xs:appinfo>
+            <xs:documentation>
+               <b>An OVERLOAD/@z</b>: A flag on an assembly called 'OVERLOAD'</xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
    <xs:complexType name="everything-assembly-empty-ASSEMBLY">
       <xs:annotation>


### PR DESCRIPTION
# Committer Notes

Metaschema-based converter generator now properly supports recursive elements in context even when not distinguished by name (for example, two different kinds of `part` assemblies, each one of which recursively contains more such parts).

Not handling: mixed/promiscuous structures with name collisions / assembly group type SINGLETON-OR-ARRAY

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
