### PR TITLE
Corrected handling of `choice` in reference pages

### DIFF
--- a/toolchains/xslt-M4/document/common-reference.xsl
+++ b/toolchains/xslt-M4/document/common-reference.xsl
@@ -159,6 +159,13 @@
       <xsl:apply-templates select="." mode="produce-constraint"/>
    </xsl:template>
    
+   <xsl:template match="choice">
+      <div class="choice">
+         <p>A choice:</p>
+         <xsl:apply-templates/>
+      </div>
+   </xsl:template>
+   
    <!--<xsl:template match="constraint" mode="produce" expand-text="true">
       <xsl:variable name="constraints" select=".//allowed-values | .//matches | .//has-cardinality | .//is-unique | .//index-has-key | .//index"/>
       <xsl:for-each-group select="$constraints" group-by="true()">

--- a/toolchains/xslt-M4/document/xml/element-reference-html.xsl
+++ b/toolchains/xslt-M4/document/xml/element-reference-html.xsl
@@ -115,10 +115,11 @@
                      <xsl:apply-templates select="current-group()"/>
                   </details>
                </xsl:for-each-group>
-               <xsl:for-each-group select="element" group-by="true()">
+               <xsl:for-each-group select="element | choice[exists(child::element)]" group-by="true()">
+                  <xsl:variable name="elements" select="current-group()/ (self::element | child::element)"/>
                   <details class="properties elements" open="open">
                      <summary>
-                        <xsl:text expand-text="true">{ if (count(current-group()) gt 1) then 'Elements' else 'Element' } ({ count(current-group()) })</xsl:text>
+                        <xsl:text expand-text="true">{ if (count($elements) gt 1) then 'Elements' else 'Element' } ({ count($elements) })</xsl:text>
                      </summary>
                      <xsl:apply-templates select="current-group()"/>
                   </details>
@@ -128,6 +129,7 @@
          </xsl:where-populated>
       </div>
    </xsl:template>
+   
    
    <xsl:template match="formal-name | description | remarks | constraint"/>
    


### PR DESCRIPTION
# Committer Notes

As noted. JSON pages were referencing locations that were being dropped in the XML pages.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
