### PR TITLE
Document generation finer tuning

### DIFF
--- a/toolchains/xslt-M4/document/hugo-css-emulator.xsl
+++ b/toolchains/xslt-M4/document/hugo-css-emulator.xsl
@@ -48,18 +48,19 @@
       </html>
    </xsl:template>
    
-   <xsl:template match="a/@href[starts-with(.,'../..')]">
-     <xsl:attribute name="href" select="substring-after(.,'../../')"/>
+   <xsl:template match="a/@href[starts-with(.,'../')]">
+     <xsl:attribute name="href" expand-text="true">{ $metaschema-code }-{ substring-after(.,'../') }</xsl:attribute>
    </xsl:template>
    
-   <xsl:template match="/div" name="toc-level" mode="toc">
+   <xsl:template priority="10" match="/div" name="toc-level" mode="toc">
       <ul class="toc">
-         <xsl:apply-templates select="section" mode="#current"/>
+         <xsl:apply-templates select="child::div[contains-token(@class,'model-entry')]" mode="#current"/>
       </ul>
    </xsl:template>
    
-   <xsl:template match="section" mode="toc">
-     <xsl:variable name="head" select="*[starts-with(@class,'toc')] | *[@class='header']/descendant::*[starts-with(@class,'toc')][1]"/>
+  <xsl:template match="div[contains-token(@class,'model-entry')]" mode="toc">
+    <xsl:variable name="head" select="(descendant::h1 | descendant::h2 | descendant::h3 | descendant::h4 | descendant::h5 | descendant::h6 )[1]"/>
+    <xsl:variable name="h-level" select="$head ! replace(name(),'\D','') ! number()"/>
             <li>
                <xsl:for-each select="$head" expand-text="true">
                   <p><a href="#{ $head/@id }">{ . }</a></p>

--- a/toolchains/xslt-M4/document/json/object-tree.xsl
+++ b/toolchains/xslt-M4/document/json/object-tree.xsl
@@ -10,6 +10,8 @@
     exclude-result-prefixes="#all"
     version="3.0">
     
+    <xsl:output indent="yes"/>
+    
     <xsl:mode on-no-match="shallow-copy"/>
     
     <!--
@@ -104,6 +106,17 @@
             <xsl:apply-templates select="@* except @key"/>
             <xsl:apply-templates/>
         </object>
+    </xsl:template>
+    
+    <!--IDs on assemblies and fields with dynamic key flags are adjusted
+    to reflect the position of the target node in the represented hierarchy -->
+    <xsl:template match="assembly[exists(@json-key-flag)]/@_tree-xml-id |
+                         field[exists(@json-key-flag)]/@_tree-xml-id |
+                         assembly[exists(@json-key-flag)]/@_tree-json-id |
+                         field[exists(@json-key-flag)]/@_tree-json-id">
+        <xsl:attribute name="{name()}">
+            <xsl:value-of select="(.,../@json-key-flag) => string-join('/')"/>
+        </xsl:attribute>
     </xsl:template>
     
     <xsl:template priority="3" match="group[exists(@json-key-flag)]/field[not(flag/@name != @json-key-flag)]">

--- a/toolchains/xslt-M4/document/xml/element-reference-html.xsl
+++ b/toolchains/xslt-M4/document/xml/element-reference-html.xsl
@@ -89,44 +89,7 @@
             <xsl:call-template name="crosslink-to-json"/>
             <!--<xsl:apply-templates select="formal-name" mode="produce"/>-->
          </div>
-         <!--<xsl:where-populated>
-            <div class="body">
-               
-               
-               <xsl:apply-templates select="description" mode="produce"/>
-               <xsl:apply-templates select="value" mode="produce"/>
-               <xsl:call-template name="remarks-group"/>
-               
-               <xsl:variable name="my-constraints"
-                  select="constraint/( descendant::allowed-values | descendant::matches | descendant::has-cardinality | descendant::is-unique | descendant::index-has-key | descendant::index )"/>
-               <xsl:if test="exists($my-constraints)">
-                  <details class="constraints" open="open">
-                     <summary>
-                        <xsl:text expand-text="true">{ if ( count($my-constraints) gt 1) then 'Constraints' else 'Constraint' } ({ count($my-constraints) })</xsl:text>
-                     </summary>
-                     <xsl:apply-templates select="$my-constraints" mode="produce-constraint"/>
-                  </details>
-               </xsl:if>
-               <xsl:for-each-group select="attribute" group-by="true()">
-                  <details class="properties attributes" open="open">
-                     <summary>
-                        <xsl:text expand-text="true">{ if (count(current-group()) gt 1) then 'Attributes' else 'Attribute' } ({ count(current-group()) })</xsl:text>
-                     </summary>
-                     <xsl:apply-templates select="current-group()"/>
-                  </details>
-               </xsl:for-each-group>
-               <xsl:for-each-group select="element | choice[exists(child::element)]" group-by="true()">
-                  <xsl:variable name="elements" select="current-group()/ (self::element | child::element)"/>
-                  <details class="properties elements" open="open">
-                     <summary>
-                        <xsl:text expand-text="true">{ if (count($elements) gt 1) then 'Elements' else 'Element' } ({ count($elements) })</xsl:text>
-                     </summary>
-                     <xsl:apply-templates select="current-group()"/>
-                  </details>
-               </xsl:for-each-group>
-               
-            </div>
-         </xsl:where-populated>-->
+         
       </div>
    </xsl:template>
    
@@ -157,7 +120,7 @@
          <xsl:where-populated>
             <div class="body">
                <xsl:apply-templates select="description" mode="produce"/>
-               <!--<xsl:apply-templates select="value" mode="produce"/>-->
+               <xsl:apply-templates select="value" mode="produce"/>
                <xsl:call-template name="remarks-group"/>
                
                <xsl:variable name="my-constraints"
@@ -178,8 +141,8 @@
                      <xsl:apply-templates select="current-group()"/>
                   </details>
                </xsl:for-each-group>
-               <xsl:for-each-group select="element | choice[exists(child::element)] | value[empty(@gi)]" group-by="true()">
-                  <xsl:variable name="elements" select="current-group()/ (self::element | child::element)"/>
+               <xsl:for-each-group select="element | choice[exists(child::element)]" group-by="true()">
+                  <xsl:variable name="elements" select="current-group()/ (self::element | self::choice/child::element)"/>
                   <details class="properties elements" open="open">
                      <summary>
                         <xsl:text expand-text="true">{ if (count($elements) gt 1) then 'Elements' else 'Element' } ({ count($elements) })</xsl:text>
@@ -197,8 +160,8 @@
    <xsl:template match="formal-name | description | remarks | constraint"/>
    
    <xsl:template match="value" mode="produce" expand-text="true">
-      <div class="value" id="{ @tree-xml-id }">
-         <p>Value: { if (matches(@as-type,'^[aeiou]','i')) then 'An ' else 'A '}{ @as-type } </p>
+      <div class="value">
+         <p>Value: { if (matches(@as-type,'^[aeiou]','i')) then 'An ' else 'A '}{ @as-type } value.</p>
       </div>
    </xsl:template>
    

--- a/toolchains/xslt-M4/make-any-metaschema-docs.xpl
+++ b/toolchains/xslt-M4/make-any-metaschema-docs.xpl
@@ -34,7 +34,19 @@
   
   <p:input port="parameters" kind="parameter"/>
 
-  <p:option name="metaschema-id" select="'oscal'"/>
+  <!--<p:option name="metaschema-id" select="'oscal'"/>-->
+  
+  <p:option name="output-path" required="true"/>
+  <p:option name="metaschema-id" select="'oscal_catalog_metaschema'"/>
+  
+  <p:option name="json-outline-filename"     select="'json-outline.html'"/>
+  <p:option name="json-reference-filename"   select="'json-reference.html'"/>
+  <p:option name="json-index-filename"       select="'json-index.html'"/>
+  <p:option name="json-definitions-filename" select="'json-definitions.html'"/>
+  <p:option name="xml-outline-filename"      select="'xml-outline.html'"/>
+  <p:option name="xml-reference-filename"    select="'xml-reference.html'"/>
+  <p:option name="xml-index-filename"        select="'xml-index.html'"/>
+  <p:option name="xml-definitions-filename"  select="'xml-definitions.html'"/>
   
   <!-- preview ports permit examining pipeline inputs -->
   <p:serialization port="_a.echo-input" indent="true"/>
@@ -112,11 +124,25 @@
     <p:pipe        port="result"                step="style-xml-definitions"/>
   </p:output>
   
+  <p:serialization port="_DIAGNOSTIC_" indent="true"/>
+  <p:output        port="_DIAGNOSTIC_" primary="false">
+    <p:pipe        port="result"                step="render-json-object-reference"/>
+  </p:output>
+  
   <!-- &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& -->
   <!-- Import (subpipeline) -->
 
   <p:import href="compose/metaschema-compose.xpl"/>
 
+  <p:variable name="xml-outline-uri"      select="resolve-uri($xml-outline-filename,     $output-path)"/>
+  <p:variable name="xml-reference-uri"    select="resolve-uri($xml-reference-filename,   $output-path)"/>
+  <p:variable name="xml-index-uri"        select="resolve-uri($xml-index-filename,       $output-path)"/>
+  <p:variable name="xml-definitions-uri"  select="resolve-uri($xml-definitions-filename, $output-path)"/>
+  <p:variable name="json-outline-uri"     select="resolve-uri($json-outline-filename,    $output-path)"/>
+  <p:variable name="json-reference-uri"   select="resolve-uri($json-reference-filename,  $output-path)"/>
+  <p:variable name="json-index-uri"       select="resolve-uri($json-index-filename,      $output-path)"/>
+  <p:variable name="json-definitions-uri" select="resolve-uri($json-definitions-filename,$output-path)"/>
+  
   <!-- &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& &&& -->
   <!-- Pipeline -->
 
@@ -167,7 +193,8 @@
     <p:input port="stylesheet">
       <p:document href="document/xml/element-map-html.xsl"/>
     </p:input>
-    <p:with-param name="reference-page" select="$metaschema-id || '-xml-reference.html'"/>
+    <p:with-param name="outline-page"   select="$xml-outline-filename"/>
+    <p:with-param name="reference-page" select="$xml-reference-filename"/>
   </p:xslt>
   
   <p:xslt name="style-xml-model-map">
@@ -187,8 +214,10 @@
     <p:input port="stylesheet">
       <p:document href="document/xml/element-reference-html.xsl"/>
     </p:input>
-    <p:with-param name="json-reference-page" select="$metaschema-id || '-json-reference.html'"/>
-    <p:with-param name="xml-map-page" select="$metaschema-id || '-xml-outline.html'"/>
+    <p:with-param name="xml-reference-page"    select="$xml-reference-filename"/>
+    <p:with-param name="xml-definitions-page"  select="$xml-definitions-filename"/>
+    <p:with-param name="json-reference-page"   select="$json-reference-filename"/>
+    <p:with-param name="xml-map-page"          select="$xml-outline-filename"/>
   </p:xslt>
   
   <!--  Wrapping this up to write and view locally/standalone if wanted -->
@@ -210,8 +239,9 @@
     <p:input port="stylesheet">
       <p:document href="document/xml/element-index-html.xsl"/>
     </p:input>
-    <p:with-param name="reference-page" select="$metaschema-id || '-xml-reference.html'"/>
-    <p:with-param name="definitions-page" select="$metaschema-id || '-xml-definitions.html'"/>
+    <p:with-param name="index-page"       select="$xml-index-filename"/>
+    <p:with-param name="reference-page"   select="$xml-reference-filename"/>
+    <p:with-param name="definitions-page" select="$xml-definitions-filename"/>
   </p:xslt>
   
   <p:xslt name="style-xml-element-index">
@@ -234,8 +264,9 @@
       <!-- XXX fix up / reduce this XSLT (from RC2) -->
       <p:document href="document/xml/xml-definitions.xsl"/>
     </p:input>
-    <p:with-param name="xml-reference-page" select="$metaschema-id || '-xml-reference.html'"/>    
-    <p:with-param name="json-definitions-page" select="$metaschema-id || '-json-definitions.html'"/>
+    <p:with-param name="xml-definitions-page"  select="$xml-definitions-filename"/>
+    <p:with-param name="json-definitions-page" select="$json-definitions-filename"/>
+    <p:with-param name="xml-reference-page"    select="$xml-reference-filename"/>    
   </p:xslt>
   
   <p:xslt name="style-xml-definitions">
@@ -264,7 +295,8 @@
     <p:input port="stylesheet">
       <p:document href="document/json/object-map-html.xsl"/>
     </p:input>
-    <p:with-param name="reference-page" select="$metaschema-id || '-json-reference.html'"/>
+    <p:with-param name="outline-page"   select="$json-outline-filename"/>
+    <p:with-param name="reference-page" select="$json-reference-filename"/>
   </p:xslt>
 
   <!--  Next we wrap this up to write and view locally/standalone if wanted -->
@@ -293,8 +325,10 @@
     <p:input port="stylesheet">
       <p:document href="document/json/object-reference-html.xsl"/>
     </p:input>
-    <p:with-param name="xml-reference-page" select="$metaschema-id || '-xml-reference.html'"/>
-    <p:with-param name="json-map-page" select="$metaschema-id || '-json-outline.html'"/>
+    <p:with-param name="json-reference-page"   select="$json-reference-filename"/>
+    <p:with-param name="json-definitions-page" select="$json-definitions-filename"/>
+    <p:with-param name="xml-reference-page"    select="$xml-reference-filename"/>
+    <p:with-param name="json-map-page"         select="$json-outline-filename"/>
   </p:xslt>
 
   <!--  Wrapping this up to write and view locally/standalone if wanted -->
@@ -318,8 +352,9 @@
     <p:input port="stylesheet">
       <p:document href="document/json/object-index-html.xsl"/>
     </p:input>
-    <p:with-param name="reference-page" select="$metaschema-id || '-json-reference.html'"/>
-    <p:with-param name="definitions-page" select="$metaschema-id || '-json-definitions.html'"/>
+    <p:with-param name="index-page"       select="$json-index-filename"/>
+    <p:with-param name="reference-page"   select="$json-reference-filename"/>
+    <p:with-param name="definitions-page" select="$json-definitions-filename"/>
   </p:xslt>
   
   <p:xslt name="style-json-object-index">
@@ -341,8 +376,9 @@
       <!-- XXX fix up / reduce this XSLT (from RC2) -->
       <p:document href="document/json/json-definitions.xsl"/>
     </p:input>
-    <p:with-param name="xml-definitions-page" select="$metaschema-id || '-xml-definitions.html'"/>
-    <p:with-param name="json-reference-page" select="$metaschema-id || '-json-reference.html'"/>
+    <p:with-param name="json-definitions-page" select="$json-definitions-filename"/>
+    <p:with-param name="xml-definitions-page"  select="$xml-definitions-filename"/>
+    <p:with-param name="json-reference-page"   select="$json-reference-filename"/>
   </p:xslt>
 
   <p:xslt name="style-json-definitions">

--- a/toolchains/xslt-M4/write-hugo-metaschema-docs.xpl
+++ b/toolchains/xslt-M4/write-hugo-metaschema-docs.xpl
@@ -49,13 +49,6 @@
 
   <p:identity name="composed"/>
 
-  <!--<p:identity  name="render-xml-model-map"/>-->
-  <p:xslt name="annotate-composition">
-    <p:input port="stylesheet">
-      <p:document href="compose/annotate-composition.xsl"/>
-    </p:input>
-  </p:xslt>
-  
   <p:xslt name="make-abstract-map">
     <p:input port="stylesheet">
       <p:document href="compose/make-model-map.xsl"/>


### PR DESCRIPTION
# Committer Notes

Restored dropped link to (implicit) JSON value node on objects with properties-by-key (json-key-flags), as exemplified in RC2 metaschemas. Repaired a couple of small errors found in testing e.g. element counts given in expanders on the XML reference page.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
