### PR TITLE
Repairing link bug in generated docs (for RC2)

### DIFF
--- a/toolchains/xslt-M4/document/xml/element-tree.xsl
+++ b/toolchains/xslt-M4/document/xml/element-tree.xsl
@@ -20,8 +20,8 @@
     
     <xsl:template match="assembly | field | group">
         <element>
-            <xsl:call-template name="mark-path"/>
             <xsl:apply-templates select="@*"/>
+            <xsl:call-template name="mark-path"/>
             <xsl:apply-templates/>
         </element>
     </xsl:template>
@@ -29,7 +29,7 @@
 <!-- The points of misalignment between the XML and object models
      are bridged by including a JSON path for the parent (wrapper) when none is on the node. -->
     <xsl:template name="mark-path">
-        <xsl:if test="empty(@_tree-json-id)">
+        <xsl:if test="empty(@_tree-json-id) or (parent::group/@in-xml='HIDDEN')">
             <xsl:apply-templates select="../@_tree-json-id"/>
         </xsl:if>
     </xsl:template>
@@ -46,8 +46,8 @@
     
     <xsl:template match="flag">
         <attribute>
-            <xsl:call-template name="mark-path"/>
             <xsl:apply-templates select="@*"/>
+            <xsl:call-template name="mark-path"/>
             <xsl:apply-templates/>
         </attribute>
     </xsl:template>
@@ -60,8 +60,8 @@
     
     <xsl:template match="field[@as-type='markup-multiline']">
         <element>
-            <xsl:call-template name="mark-path"/>
             <xsl:apply-templates select="@*"/>
+            <xsl:call-template name="mark-path"/>
             <xsl:apply-templates/>
         </element>
     </xsl:template>


### PR DESCRIPTION
# Committer Notes

Adjusting XML element tree for functional cross-linking on BY_KEY objects, affecting RC2 docs production.

Results (generated docs) pass local link checking for both RC2 and 1.0.0 metaschema inputs.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
