### PR TITLE
Writing XSDs in US-ASCII

### DIFF
--- a/toolchains/xslt-M4/make-metaschema-xsd.xpl
+++ b/toolchains/xslt-M4/make-metaschema-xsd.xpl
@@ -30,7 +30,8 @@
     <p:pipe        port="result" step="rewire-xsd"/>
   </p:output>
   
-  <p:serialization port="f.final" indent="true" method="xml" omit-xml-declaration="false"/>
+  <!-- us-ascii encoding to provide escaping on upper-ASCII characters in the schema -->
+  <p:serialization port="f.final" indent="true" method="xml" omit-xml-declaration="false" encoding="us-ascii"/>
   <p:output        port="f.final" primary="true">
     <p:pipe        port="result" step="final"/>
   </p:output>

--- a/toolchains/xslt-M4/nist-metaschema-MAKE-XSD.xsl
+++ b/toolchains/xslt-M4/nist-metaschema-MAKE-XSD.xsl
@@ -13,7 +13,7 @@
     
     -->
 
-    <xsl:output method="xml" indent="yes"/>
+    <xsl:output method="xml" indent="yes" encoding="us-ascii"/>
 
     <!-- Turning $trace to 'on' will
          - emit runtime messages with each transformation, and


### PR DESCRIPTION
# Committer Notes

This (re)configures serialization in the main `make-metaschema-xsd.xsl` XSLT (and in the debug XProc for reference). Setting `encoding` to emit US-ASCII provides for expressing all out-of-ASCII Unicode as (escaped) Unicode character references.

The PR addresses usnistgov/OSCAL#956.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
