### PR TITLE
Integrate use of oscal-prose-module.xsd in metaschema.xsd

### DIFF
--- a/toolchains/xslt-M4/schema-gen/oscal-prose-module.xsd
+++ b/toolchains/xslt-M4/schema-gen/oscal-prose-module.xsd
@@ -2,30 +2,33 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 
   <xs:complexType name="markupLineType" mixed="true">
-    <xs:group ref="mixedInlineMarkupGroup"/>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="inlineMarkupGroup"/>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="markupMultilineType">
-    <xs:group ref="blockElementGroup"/>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="blockElementGroup"/>
+    </xs:choice>
   </xs:complexType>
 
   <xs:group name="blockElementGroup">
-    <xs:sequence>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element name="h1"    type="blockElementType"/>
-        <xs:element name="h2"    type="blockElementType"/>
-        <xs:element name="h3"    type="blockElementType"/>
-        <xs:element name="h4"    type="blockElementType"/>
-        <xs:element name="h5"    type="blockElementType"/>
-        <xs:element name="h6"    type="blockElementType"/>
-        <xs:element name="p"     type="blockElementType"/>
-        <xs:element name="ul"    type="listType"/>
-        <xs:element name="ol"    type="listType"/>
-        <xs:element name="pre"   type="preformattedType"/>
-        <xs:element name="table" type="tableType"/>
-        <!-- TODO: need to add support for blockquote, which can contain block elements. usnistgov/metaschema#70 -->
-      </xs:choice>
-    </xs:sequence>
+    <xs:choice>
+      <xs:element name="h1"    type="inlineType"/>
+      <xs:element name="h2"    type="inlineType"/>
+      <xs:element name="h3"    type="inlineType"/>
+      <xs:element name="h4"    type="inlineType"/>
+      <xs:element name="h5"    type="inlineType"/>
+      <xs:element name="h6"    type="inlineType"/>
+      <xs:element name="p"     type="inlineType"/>
+      <xs:element name="ul"    type="listType"/>
+      <xs:element name="ol"    type="listType"/>
+      <xs:element name="pre"   type="preformattedType"/>
+      <xs:element name="table" type="tableType"/>
+      <xs:element name="img" type="imageType"/>
+      <!-- TODO: need to add support for blockquote, which can contain block elements. usnistgov/metaschema#70 -->
+    </xs:choice>
   </xs:group>
 
   <!--
@@ -37,26 +40,17 @@
   -->
 
 
-  <xs:complexType name="blockElementType" mixed="true">
-    <xs:group ref="phraseInlineMarkupGroup"/>
-  </xs:complexType>
-
-  <xs:complexType name="headingType" mixed="true">
-    <xs:complexContent>
-      <xs:extension base="blockElementType">
-        <xs:annotation>
-          <xs:documentation>The content model is the same as blockElementType, but line endings need
-            to be preserved, since this is preformatted.</xs:documentation>
-        </xs:annotation>
-      </xs:extension>
-    </xs:complexContent>
+  <xs:complexType name="inlineType" mixed="true">
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="inlineMarkupGroup"/>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="preformattedType" mixed="true">
     <xs:complexContent>
-      <xs:extension base="blockElementType">
+      <xs:extension base="inlineType">
         <xs:annotation>
-          <xs:documentation>The content model is the same as blockElementType, but line endings need
+          <xs:documentation>The content model is the same as inlineType, but line endings need
             to be preserved, since this is preformatted.</xs:documentation>
         </xs:annotation>
       </xs:extension>
@@ -70,8 +64,9 @@
   </xs:complexType>
 
   <xs:complexType name="listItemType" mixed="true">
+    <!-- TODO: is this the correct construction? -->
     <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:group ref="mixedInlineMarkupGroup"/>
+      <xs:group ref="inlineMarkupGroup"/>
       <xs:element name="ul" type="listType"/>
       <xs:element name="ol" type="listType"/>
     </xs:choice>
@@ -85,17 +80,20 @@
 
   <xs:complexType name="tableRowType">
     <!-- QUESTION: Should we allow TH and TD to be mixed? -->
-    <xs:choice minOccurs="0" maxOccurs="unbounded">
+    <xs:choice minOccurs="1" maxOccurs="unbounded">
       <xs:element name="td" type="tableCellType" maxOccurs="unbounded"/>
       <xs:element name="th" type="tableCellType" maxOccurs="unbounded"/>
     </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="tableCellType" mixed="true">
-    <xs:group ref="mixedInlineMarkupGroup"/>
-    <!-- TODO: consider adding a choice between the inline or paragraphs. We need to figure out what is supported in Markdown. -->
-    <xs:attribute name="align" type="alignType" default="left"/>
-    <!-- TODO: need to add support for alignment. usnistgov/metaschema#70 -->
+    <xs:complexContent>
+      <!-- TODO: consider adding a choice between the inline or paragraphs. We need to figure out what is supported in Markdown. -->
+      <xs:extension base="inlineType">
+        <!-- TODO: need to add support for alignment. usnistgov/metaschema#70 -->
+        <xs:attribute name="align" type="alignType" default="left"/>
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 
   <xs:simpleType name="alignType">
@@ -106,44 +104,46 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <!-- note mix does not include anchors, which do not come for free -->
-  <xs:group name="mixedInlineMarkupGroup">
-    <xs:sequence>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:group ref="phraseInlineMarkupGroup"/>
-        <xs:element name="img" type="imageType"/>
-      </xs:choice>
-    </xs:sequence>
+  <xs:group name="inlineMarkupGroup">
+    <xs:choice>
+      <xs:element name="a" type="anchorType"/>
+      <xs:element name="insert" type="insertType"/>
+      <xs:group ref="phraseMarkupGroup"/>
+      <xs:group ref="imageMarkupGroup"/>
+    </xs:choice>
   </xs:group>
-
-  <xs:group name="phraseInlineMarkupGroup">
-    <xs:sequence>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
-        <xs:element name="code" type="inlineMarkupType" minOccurs="1"/>
-        <xs:element name="em" type="inlineMarkupType" minOccurs="1"/>
-        <xs:element name="i" type="inlineMarkupType" minOccurs="1"/>
-        <xs:element name="b" type="inlineMarkupType" minOccurs="1"/>
-        <xs:element name="strong" type="inlineMarkupType" minOccurs="1"/>
-        <xs:element name="sub" type="inlineMarkupType" minOccurs="1"/>
-        <xs:element name="sup" type="inlineMarkupType" minOccurs="1"/>
-        <xs:element name="q" type="inlineMarkupType" minOccurs="1"/>
-        <xs:element name="insert" type="insertType"/>
-        <xs:element name="a" type="anchorType"/>
-      </xs:choice>
-    </xs:sequence>
+  <xs:group name="imageMarkupGroup">
+    <xs:choice>
+      <xs:element name="img" type="imageType"/>
+    </xs:choice>
   </xs:group>
-
+  <xs:group name="phraseMarkupGroup">
+    <xs:choice>
+      <xs:element name="code" type="inlineMarkupType" minOccurs="1"/>
+      <xs:element name="em" type="inlineMarkupType" minOccurs="1"/>
+      <xs:element name="i" type="inlineMarkupType" minOccurs="1"/>
+      <xs:element name="b" type="inlineMarkupType" minOccurs="1"/>
+      <xs:element name="strong" type="inlineMarkupType" minOccurs="1"/>
+      <xs:element name="sub" type="inlineMarkupType" minOccurs="1"/>
+      <xs:element name="sup" type="inlineMarkupType" minOccurs="1"/>
+      <xs:element name="q" type="inlineMarkupType" minOccurs="1"/>
+    </xs:choice>
+  </xs:group>
   <xs:complexType name="inlineMarkupType" mixed="true">
-    <xs:group ref="phraseInlineMarkupGroup"/>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="inlineMarkupGroup"/>
+    </xs:choice>
   </xs:complexType>
-
   <xs:complexType name="imageType">
     <xs:attribute name="alt" type="xs:string"/>
     <xs:attribute name="src" use="required" type="xs:anyURI"/>
   </xs:complexType>
 
   <xs:complexType name="anchorType" mixed="true">
-    <xs:group ref="phraseInlineMarkupGroup"/>
+    <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:group ref="phraseMarkupGroup"/>
+      <xs:group ref="imageMarkupGroup"/>
+    </xs:choice>
     <xs:attribute name="href" type="xs:anyURI"/>
   </xs:complexType>
 

--- a/toolchains/xslt-M4/schema-gen/oscal-prose-module.xsd
+++ b/toolchains/xslt-M4/schema-gen/oscal-prose-module.xsd
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-  targetNamespace="http://csrc.nist.gov/ns/oscal/1.0" xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 
   <xs:complexType name="markupLineType" mixed="true">
     <xs:group ref="mixedInlineMarkupGroup"/>

--- a/toolchains/xslt-M4/validate/metaschema.xsd
+++ b/toolchains/xslt-M4/validate/metaschema.xsd
@@ -4,6 +4,12 @@
   xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0"
   targetNamespace="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
 
+  <xs:include schemaLocation="../schema-gen/oscal-prose-module.xsd">
+    <xs:annotation>
+      <xs:documentation>This prose module provides support for line and multiline markup.</xs:documentation>
+    </xs:annotation>
+  </xs:include>
+
   <!-- Import any OSCAL schemas needed for samples... -->
   <!--<xs:import namespace="http://csrc.nist.gov/ns/oscal/1.0"
     schemaLocation="../../../schema/xml/oscal-catalog-schema.xsd"/>-->
@@ -67,7 +73,7 @@
       <xs:choice  minOccurs="0" maxOccurs="unbounded">
         <xs:element ref="flag"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" name="define-flag"
-          type="LocalFlagDefinitionType"/>
+          type="InlineFlagDefinitionType"/>
       </xs:choice>
       <xs:element name="model" minOccurs="0" type="AssemblyModelType"/>
       <xs:element minOccurs="0" name="constraint" type="DefineAssemblyConstraintsType"/>
@@ -85,8 +91,8 @@
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element ref="assembly"/>
         <xs:element ref="field"/>
-        <xs:element name="define-assembly" type="LocalAssemblyDefinitionType"/>
-        <xs:element name="define-field" type="LocalFieldDefinitionType"/>
+        <xs:element name="define-assembly" type="InlineAssemblyDefinitionType"/>
+        <xs:element name="define-field" type="InlineFieldDefinitionType"/>
         <xs:element ref="choice"/>
       </xs:choice>
       <xs:element ref="any" minOccurs="0"/>
@@ -96,7 +102,7 @@
   <xs:complexType name="GlobalFieldDefinitionType">
     <xs:annotation>
       <xs:documentation>In JSON, an object with a nominal string value (potentially with internal
-        inline - not fully structured - markup). In XML, an element with string or mixed
+        inline - not fully structured - markup). In XML, an element with string or markup
         content. Defined globally, a field can be assigned to appear in the <code>model</code> of any assembly by <code>field</code> reference.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
@@ -108,7 +114,7 @@
       <xs:choice  minOccurs="0" maxOccurs="unbounded">
         <xs:element ref="flag"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" name="define-flag"
-          type="LocalFlagDefinitionType"/>
+          type="InlineFlagDefinitionType"/>
       </xs:choice>
       <xs:element minOccurs="0" name="constraint" type="DefineFieldConstraintsType"/>
       <xs:element minOccurs="0" ref="remarks"/>
@@ -145,10 +151,10 @@
     <xs:anyAttribute processContents="lax"/>
   </xs:complexType>
 
-  <xs:complexType name="LocalAssemblyDefinitionType">
+  <xs:complexType name="InlineAssemblyDefinitionType">
     <xs:annotation>
       <xs:documentation>In JSON, an object with a nominal string value (potentially with internal
-        inline - not fully structured - markup). In XML, an element with string or mixed
+        inline - not fully structured - markup). In XML, an element with string or markup
         content. A local definition describes and constrains the appearance of the field only in this (assembly) context.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
@@ -161,7 +167,7 @@
       <xs:choice  minOccurs="0" maxOccurs="unbounded">
         <xs:element ref="flag"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" name="define-flag"
-          type="LocalFlagDefinitionType"/>
+          type="InlineFlagDefinitionType"/>
       </xs:choice>
       <xs:element name="model" minOccurs="0" type="AssemblyModelType"/>
       <xs:element minOccurs="0" name="constraint" type="DefineAssemblyConstraintsType"/>
@@ -175,10 +181,10 @@
   </xs:complexType>
 
 
-  <xs:complexType name="LocalFieldDefinitionType">
+  <xs:complexType name="InlineFieldDefinitionType">
     <xs:annotation>
       <xs:documentation>In JSON, an object with a nominal string value (potentially with internal
-        inline - not fully structured - markup). In XML, an element with string or mixed
+        inline - not fully structured - markup). In XML, an element with string or markup
         content. A local definition describes and constrains the appearance of the field only in this (assembly) context.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
@@ -191,7 +197,7 @@
       <xs:choice  minOccurs="0" maxOccurs="unbounded">
         <xs:element ref="flag"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" name="define-flag"
-          type="LocalFlagDefinitionType"/>
+          type="InlineFlagDefinitionType"/>
       </xs:choice>
       <xs:element minOccurs="0" name="constraint" type="DefineFieldConstraintsType"/>
       <xs:element minOccurs="0" ref="remarks"/>
@@ -211,7 +217,7 @@
     <xs:anyAttribute processContents="lax"/>
   </xs:complexType>
 
-  <xs:complexType name="LocalFlagDefinitionType">
+  <xs:complexType name="InlineFlagDefinitionType">
     <xs:annotation>
       <xs:documentation>A data point to be expressed as an attribute in the XML or a name/value pair in the JSON. A local definition describes and constrains the appearance of the flag only in its parent (assembly or field) context.</xs:documentation>
     </xs:annotation>
@@ -255,24 +261,8 @@
       <xs:documentation>The JSON Base URI is nominal base URI assigned to a JSON Schema instance expressing the model defined by this metaschema.</xs:documentation>
     </xs:annotation>
   </xs:element>
-  
-  <xs:group name="MarkupElementsGroup">
-    <xs:sequence>
-      <xs:choice maxOccurs="unbounded">
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="a"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="code"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="q"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="em"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="strong"/>
-      </xs:choice>
-    </xs:sequence>
-  </xs:group>
-
-  <xs:complexType name="MarkupLineType" mixed="true">
-    <xs:group ref="MarkupElementsGroup"/>
-  </xs:complexType>
-
-  <xs:element name="description" type="MarkupLineType">
+ 
+  <xs:element name="description" type="markupLineType">
     <xs:annotation>
       <xs:documentation>A short description of the data construct, to be inserted into
         documentation. Unlike 'formal-name' this should not simply repeat what is readily
@@ -288,7 +278,7 @@
     </xs:annotation>
     <xs:complexType>
       <xs:complexContent>
-        <xs:extension base="MarkupMultilineType">
+        <xs:extension base="markupMultilineType">
           <xs:attribute name="class" type="xs:NMTOKENS">
             <xs:annotation>
               <xs:documentation>Mark as 'XML' for XML-only or 'JSON' for JSON-only remarks.</xs:documentation>
@@ -299,29 +289,16 @@
     </xs:complexType>
   </xs:element>
 
-  <xs:complexType name="MarkupMultilineType">
-    <xs:sequence>
-      <xs:element maxOccurs="unbounded" ref="p"/>
-    </xs:sequence>
-  </xs:complexType>    
-
-  <xs:element name="schema-name">
+  <xs:element name="schema-name" type="markupLineType">
     <xs:annotation>
       <xs:documentation>The name of the information model to be represented by derived schemas.</xs:documentation>
     </xs:annotation>
-    <xs:complexType mixed="true">
-      <xs:choice maxOccurs="unbounded">
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="code"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="q"/>
-      </xs:choice>
-    </xs:complexType>
   </xs:element>
 
-  <xs:element name="schema-version">
+  <xs:element name="schema-version" type="xs:token">
     <xs:annotation>
       <xs:documentation>The version of the information model to be represented by derived schemas.</xs:documentation>
     </xs:annotation>
-    <xs:complexType mixed="true"/>
   </xs:element>
 
   <xs:element name="short-name" type="xs:NCName">
@@ -335,7 +312,7 @@
     <xs:annotation>
       <xs:documentation>To import a set of declarations from an out-of-line schema, supporting reuse of common information structures.</xs:documentation>
     </xs:annotation>
-    <xs:complexType mixed="true">
+    <xs:complexType>
       <xs:attribute name="href" type="xs:anyURI" use="required">
         <xs:annotation>
           <xs:documentation>A relative or absolute URI for retrieving an out-of-line metaschema module.</xs:documentation>
@@ -491,7 +468,7 @@
     </xs:annotation>
     <xs:complexType>
       <xs:complexContent>
-        <xs:extension base="MarkupLineType">
+        <xs:extension base="markupLineType">
           <xs:attribute name="value" use="required" type="xs:string">
             <xs:annotation>
               <xs:documentation>A value recognized for a flag or field.</xs:documentation>
@@ -508,23 +485,6 @@
       <xs:documentation>The associated construct has been deprecated at the specified version. Its use should be avoided if possible.</xs:documentation>
     </xs:annotation>    
   </xs:attribute>
-
-  <xs:element name="p" type="MarkupLineType">
-    <xs:annotation>
-      <xs:documentation>A paragraph or paragraph fragment, in documentation.</xs:documentation>
-    </xs:annotation>
-  </xs:element>
-
-  <xs:element name="a">
-    <xs:complexType mixed="true">
-      <xs:attribute name="href"/>
-    </xs:complexType>
-  </xs:element>
-
-  <xs:element name="q" type="xs:string"/>
-  <xs:element name="code" type="xs:string"/>
-  <xs:element name="em" type="xs:string"/>
-  <xs:element name="strong" type="xs:string"/>
 
   <xs:element name="flag">
     <xs:complexType>
@@ -909,8 +869,8 @@
       <xs:choice maxOccurs="unbounded">
         <xs:element ref="assembly"/>
         <xs:element ref="field"/>
-        <xs:element name="define-assembly" type="LocalAssemblyDefinitionType"/>
-        <xs:element name="define-field" type="LocalFieldDefinitionType"/>
+        <xs:element name="define-assembly" type="InlineAssemblyDefinitionType"/>
+        <xs:element name="define-field" type="InlineFieldDefinitionType"/>
       </xs:choice>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
# Committer Notes

The markup support in the metaschema.xsd is fairly simple and incomplete. This PR replaces the current markup support with the markup data types provided by the oscal-prose-module.xsd. 

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
