### PR TITLE
Accumulator Workaround for SaxonJS: Global Variable with `xsl:iterate`

### DIFF
--- a/toolchains/xslt-M4/compose/metaschema-compose.xpl
+++ b/toolchains/xslt-M4/compose/metaschema-compose.xpl
@@ -171,9 +171,9 @@
   
   <p:xslt name="prune-defs">
     <p:input port="stylesheet">
-      <p:document href="metaschema-prune-unused-definitions.xsl"/>
+      <p:document href="metaschema-prune-unused-definitions-a3.xsl"/>
     </p:input>
-    <p:with-param name="show-warnings" select="'yes'"/>
+    <!--<p:with-param name="show-warnings" select="'yes'"/>-->
     <!-- With EXCEPTION problem-type="missing-root" for no roots found when the metaschema is not abstract -->
     <!-- With EXCEPTION problem-type="unused-definition" for definitions removed as unused -->
   </p:xslt>

--- a/toolchains/xslt-M4/compose/metaschema-prune-unused-definitions.xsl
+++ b/toolchains/xslt-M4/compose/metaschema-prune-unused-definitions.xsl
@@ -48,31 +48,73 @@
     </xsl:function>
     
     <xsl:variable name="definitions" as="xs:string*">
-        <xsl:apply-templates select="$root-assembly-definitions" mode="collect-definitions">
-            <xsl:with-param name="keys-so-far" tunnel="true" select="()"/>
-        </xsl:apply-templates>
+        <xsl:iterate select="$root-assembly-definitions">
+            <xsl:param name="so-far" select="()" as="xs:string*"/>
+            <xsl:on-completion select="$so-far"/>
+            <xsl:variable name="key" select="m:definition-key(.)"/>
+            <xsl:variable name="captured" as="xs:string*">
+                <xsl:if test="not($key = $so-far)">
+                    <xsl:apply-templates select="." mode="collect-definitions">
+                        <xsl:with-param name="defined-so-far" select="$so-far"/>
+                    </xsl:apply-templates>
+                </xsl:if>
+            </xsl:variable>
+            <xsl:next-iteration>
+                <xsl:with-param name="so-far" select="$so-far, $captured"/>
+            </xsl:next-iteration>
+            
+        </xsl:iterate>
     </xsl:variable>
     
-    <xsl:template mode="collect-definitions" match="METASCHEMA/define-assembly |
-        METASCHEMA/define-field | METASCHEMA/define-flag">
-        <xsl:param tunnel="true" name="keys-so-far"/>
+    <xsl:template mode="collect-definitions" match="METASCHEMA/define-field | METASCHEMA/define-flag" as="xs:string*">
+        <xsl:param name="defined-so-far" select="()" as="xs:string*"/>
         <xsl:variable name="key" select="m:definition-key(.)"/>
-        <!-- guarding against infinite loops with recursive calls -->
-        <xsl:if test="not($key = $keys-so-far)">
-            <!-- emitting the key as a string value into the result -->
-            <xsl:value-of select="m:definition-key(.)"/>
-            <!-- now traversing to descendant references -->
-            <xsl:apply-templates select="descendant::flag | descendant::field | descendant::assembly" mode="#current">
-                <xsl:with-param name="keys-so-far" tunnel="true" select="$keys-so-far, $key"/>
+        <!-- now traversing to descendant references -->
+        <xsl:if test="not($key = $defined-so-far)">
+            <xsl:sequence select="$key"/>
+            <xsl:apply-templates mode="#current" select="flag">
+                <xsl:with-param name="defined-so-far" select="$defined-so-far, $key"/>
             </xsl:apply-templates>
         </xsl:if>
     </xsl:template>
     
-    <xsl:template mode="collect-definitions" match="assembly | field | flag">
-        <xsl:apply-templates select="key('m:definition-by-key',m:referencing-key(.))" mode="#current"/>
+    <xsl:template mode="collect-definitions" match="METASCHEMA/define-assembly" as="xs:string*">
+        <xsl:param name="defined-so-far" select="()" as="xs:string*"/>
+        <xsl:variable name="key" select="m:definition-key(.)"/>
+        <!-- now traversing to descendant references -->
+        <xsl:iterate select="descendant::flag | descendant::field | descendant::assembly">
+            <xsl:param name="so-far" select="$defined-so-far,$key" as="xs:string*"/>
+            <xsl:on-completion select="$so-far"/>
+            <xsl:variable name="captured" as="xs:string*">
+                <xsl:if test="not(m:referencing-key(.) = $so-far)">
+                    <xsl:apply-templates select="key('m:definition-by-key', m:referencing-key(.))"
+                        mode="#current">
+                        <xsl:with-param name="defined-so-far" select="$so-far"/>
+                    </xsl:apply-templates>
+                </xsl:if>
+            </xsl:variable>
+            <xsl:next-iteration>
+                <xsl:with-param name="so-far" select="distinct-values(($so-far,$captured))"/>
+            </xsl:next-iteration>
+            
+        </xsl:iterate>
     </xsl:template>
     
+    <!--<xsl:template mode="collect-definitions" match="assembly | field | flag" as="xs:string?">
+        <!-\- only continuing if not already visited -\->
+        <xsl:message expand-text="true">REFERENCING { m:referencing-key(.) } ACCUMULATED { accumulator-before('m:definitions-seen') }</xsl:message>
+        <xsl:if test="not(m:referencing-key(.) = accumulator-before('m:definitions-seen'))">
+            <xsl:message expand-text="true">... okay on { m:referencing-key(.) } for { count( key('m:definition-by-key',m:referencing-key(.)) ) }</xsl:message>
+          <xsl:apply-templates select="key('m:definition-by-key',m:referencing-key(.))" mode="#current"/>
+        </xsl:if>
+    </xsl:template>-->
     
+    <xsl:template mode="collect-definitions" match="flag">
+        <xsl:param name="defined-so-far" select="()" as="xs:string*"/>       
+        <xsl:apply-templates select="key('m:definition-by-key',m:referencing-key(.))" mode="#current">
+            <xsl:with-param name="defined-so-far" select="$defined-so-far"/>
+        </xsl:apply-templates>
+    </xsl:template>
     
     
     <xsl:template match="/METASCHEMA">
@@ -83,6 +125,7 @@
                 <EXCEPTION problem-type="missing-root">No root found in this metaschema composition.</EXCEPTION>
             </xsl:if>
             
+            <!-- Selecting everything so we can emit warning for things we will drop -->
             <xsl:apply-templates/>
             
         </xsl:copy>
@@ -90,39 +133,29 @@
     
     <!-- 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 -->    
     
-    <xsl:template match="METASCHEMA[not(@abstract='yes')]/define-assembly[not(exists(m:root-name) or (m:definition-key(.) = $definitions))]">
-        <!--        <xsl:comment>Root Name? <xsl:value-of select="exists(m:root-name)"/></xsl:comment>
-        <xsl:comment>Map Key <xsl:value-of select="string((substring-after(name(.),'define-'), @_key-name) => string-join('#'))"/></xsl:comment>
-        <xsl:comment>Map Contains? <xsl:value-of select="map:contains($reference-counts,string((substring-after(name(.),'define-'), @_key-ref) => string-join('#')))"/></xsl:comment>
--->
+    <!--<xsl:template match="METASCHEMA[not(@abstract='yes')]/define-assembly[not(exists(m:root-name) or (m:definition-key(.) = $definitions))]">
         <xsl:call-template name="warning">
-            <!-- since we can detect unused definitions a better way, this can be
-                 silenced and/or rendered as a comment -->
             <xsl:with-param name="type">unused-definition</xsl:with-param>
             <xsl:with-param name="msg" expand-text="true">REMOVING unused assembly definition for '{ @name }' from { ancestor::METASCHEMA[1]/@module
-                } ::: { m:definition-key(.) } : { $definitions => string-join(', ') }</xsl:with-param>
+                }</xsl:with-param>
         </xsl:call-template>
     </xsl:template>
     
     <xsl:template match="METASCHEMA[not(@abstract='yes')]/define-field[not(m:definition-key(.) = $definitions)]">
         <xsl:call-template name="warning">
-            <!-- since we can detect unused definitions a better way, this can be
-                 silenced and/or rendered as a comment -->
             <xsl:with-param name="type">unused-definition</xsl:with-param>
             <xsl:with-param name="msg" expand-text="true">REMOVING unused field definition for '{ @name }' from { ancestor::METASCHEMA[1]/@module
-                } ::: { m:definition-key(.) }</xsl:with-param>
+                }</xsl:with-param>
         </xsl:call-template>
     </xsl:template>
     
     <xsl:template match="METASCHEMA[not(@abstract='yes')]/define-flag[not(m:definition-key(.) = $definitions)]">
         <xsl:call-template name="warning">
-            <!-- since we can detect unused definitions a better way, this can be
-                 silenced and/or rendered as a comment -->
             <xsl:with-param name="type">unused-definition</xsl:with-param>
             <xsl:with-param name="msg" expand-text="true">REMOVING unused flag definition for '{ @name }' from { ancestor::METASCHEMA[1]/@module
-                } ::: { m:definition-key(.) }</xsl:with-param>
+                }</xsl:with-param>
         </xsl:call-template>
-    </xsl:template>
+    </xsl:template>-->
     
     <xsl:template name="warning">
         <xsl:param name="msg"/>


### PR DESCRIPTION
# Committer Notes

This is one solution to issues with using SaxonJS and `accumulate-after` function calls. Closes usnistgov/metaschema#180.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~
