### PR TITLE
Repairing JSON Schema generation

### DIFF
--- a/toolchains/xslt-M4/schema-gen/metaschema-v090-datatypes.json
+++ b/toolchains/xslt-M4/schema-gen/metaschema-v090-datatypes.json
@@ -1,0 +1,104 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "$id" : "http://csrc.nist.gov/ns/oscal/1.0/metaschema-datatypes-schema.json",
+  "$comment" : "OSCAL Unified Model of Models",
+  "type" : "object",
+  "definitions" : {
+    "Base64Datatype": {
+      "type": "string",
+      "pattern": "^[0-9A-Fa-f]+$"
+    },
+    "BooleanDatatype": {
+      "type": "boolean"
+    },
+    "DateDatatype": {
+      "type": "string",
+      "pattern": "^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))(Z|[+-][0-9]{2}:[0-9]{2})?$"
+    },
+    "DateWithTimezoneDatatype": {
+      "type": "string",
+      "pattern": "^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))(Z|[+-][0-9]{2}:[0-9]{2})$"
+    },
+    "DateTimeDatatype": {
+      "type": "string",
+      "pattern": "^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})?$"
+    },
+    "DateTimeWithTimezoneDatatype": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"
+    },
+    "DayTimeDurationDatatype": {
+      "type": "string",
+      "format": "duration",
+      "pattern": "^[-+]?P([-+]?[0-9]+D)?(T([-+]?[0-9]+H)?([-+]?[0-9]+M)?([-+]?[0-9]+([.,][0-9]{0,9})?S)?)?$"
+    },
+    "DecimalDatatype": {
+      "type": "number"
+    },
+    "EmailAddressDatatype": {
+      "type": "string",
+      "format": "email",
+      "pattern": "^.+@.+$"
+    },
+    "HostnameDatatype": {
+      "$ref": "#/definitions/StringDatatype",
+      "format": "idn-hostname"
+    },
+    "IntegerDatatype": {
+      "type": "integer"
+    },
+    "IPV4AddressDatatype": {
+      "type": "string",
+      "format": "ipv4",
+      "pattern": "^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$"
+    },
+    "IPV6AddressDatatype": {
+      "type": "string",
+      "format": "ipv6",
+      "pattern": "^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|[fF][eE]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::([fF]{4}(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3,3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3,3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]))$"
+    },
+    "MarkupLineDatatype": {
+      "type": "string",
+      "pattern": "^[^\n]+$"
+    },
+    "MarkupMultilineDatatype": {
+      "type": "string"
+    },
+    "NonNegativeIntegerDatatype": {
+      "$ref": "#/definitions/IntegerDatatype",
+      "minimum": 0
+    },
+    "PositiveIntegerDatatype": {
+      "$ref": "#/definitions/IntegerDatatype",
+      "minimum": 1
+    },
+    "StringDatatype": {
+      "type": "string",
+      "pattern": "^\\S(.*\\S)?$"
+    },
+    "TokenDatatype": {
+      "type": "string",
+      "pattern": "^(\\p{L}|_)(\\p{L}|\\p{N}|[.\\-_])*$"
+    },
+    "URIDatatype": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^[a-zA-Z][a-zA-Z0-9+\\-.]+:.+$"
+    },
+    "URIReferenceDatatype": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "UUIDDatatype": {
+      "type": "string",
+      "description": "A type 4 ('random' or 'pseudorandom') or type 5 UUID per RFC 4122.",
+      "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[45][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$"
+    },
+    "YearMonthDurationDatatype": {
+      "type": "string",
+      "format": "duration",
+      "pattern": "^[-+]?P([-+]?[0-9]+Y)?([-+]?[0-9]+M)?([-+]?[0-9]+W)?([-+]?[0-9]+D)?$"
+    }
+  }
+}


### PR DESCRIPTION
Addresses usnistgov/OSCAL#1260.

In this version we aligned datatypes in both XML and JSON with new type definitions. In doing so we were also relocating resources. These two initiatives (targeting different releases) were confused and a necessary file was mistakenly deleted.

CI/CD failed to catch that the JSON Schemas that result, are inoperative (indeed, throw errors as reported).

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
