### PR TITLE
Add support for arbitrary properties on definitions and instances

### DIFF
--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -165,8 +165,15 @@
     <xs:sequence>
       <xs:element name="formal-name" type="FormalNameType" minOccurs="0"/>
       <xs:element name="description" type="DescriptionType" minOccurs="0"/>
+      <xs:element name="prop" type="PropertyType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:group>
+  
+  <xs:complexType name="PropertyType">
+    <xs:attribute name="namespace" type="URIDatatype" default="http://csrc.nist.gov/ns/oscal/metaschema/1.0"/>
+    <xs:attribute name="name" type="TokenDatatype" use="required"/>
+    <xs:attribute name="value" type="TokenDatatype" use="required"/>
+  </xs:complexType>
 
   <xs:simpleType name="ModelNameType">
     <xs:annotation>


### PR DESCRIPTION
# Committer Notes

As a metaschema instance creator, I need a way to defined arbitrary properties on Metaschema definitions and instances. These properties allow me to describe, in an extensible way, additional attributes of a model element. These additional attributes have application in schema, code, and document productions based on a Metaschema instance.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
