### PR TITLE
Relocate Schema Docs Style Checking

### DIFF
--- a/toolchains/xslt-M4/validate/metaschema-composition-check.sch
+++ b/toolchains/xslt-M4/validate/metaschema-composition-check.sch
@@ -218,6 +218,11 @@
         <sch:rule context="m:p | m:li | m:pre">
             <sch:assert test="matches(.,'\S')" id="discourage-whitespace-only">Empty <name/> (is likely to distort rendition)</sch:assert>
         </sch:rule>
+
+        <sch:rule context="m:description">
+            <sch:assert role="error" test="ends-with(.,'.')" id="description-ends-with-dot">Description should end with a period.</sch:assert>
+            <sch:assert role="error" test="string-length(.) gt 6" id="description-long-enough">Description is too short.</sch:assert>
+        </sch:rule>
     </sch:pattern>
     
     


### PR DESCRIPTION
# Committer Notes

Part of usnistgov/OSCAL#801. Review and merge this relocated Schematron addition to centralize previous `rule`s from usnistgov/OSCAL#1501 at time of writing and move here per feedback.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- ~Have you added an explanation of what your changes do and why you'd like us to include them?~
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~
