### PR TITLE
Remove extra default schema value

### DIFF
--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -522,7 +522,7 @@
 
   <xs:attributeGroup name="FieldValueAttributeGroup">
     <xs:attribute name="as-type" type="FieldDatatypesType" default="string"/>
-    <xs:attribute name="default" type="StringDatatype" default="string"/>
+    <xs:attribute name="default" type="StringDatatype"/>
   </xs:attributeGroup>
 
   <xs:attributeGroup name="FlagValueAttributeGroup">


### PR DESCRIPTION
# Committer Notes

The metaschema XML Schema has the following syntax:

```xml
<xs:attribute name="default" type="StringDatatype" default="string"/>
```

The `default="string"` was accidentally included due to a bad copy-paste. This PR removes it.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
~~- [ ] Have you written new tests for your core changes, as applicable?~~
~~- [ ] Have you included examples of how to use your new feature(s)?~~
~~- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~~
