### PR TITLE
Workaround maven.restlet.org service cert expiry.

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -16,12 +16,17 @@
         the following errors:
         
         The following artifacts could not be resolved: org.restlet.jee:org.restlet:jar:2.2.2 ...
+
+        20221230 Workaround: TLS certificates for the restlet.org maven service
+        expired, see the following GitHub issue for details and status updates
+        about workaround alternative service and target or maven.restlet.org 
+        redirect. https://github.com/restlet/restlet-framework-java/issues/1390
     -->
     <repositories>
         <repository>
             <id>maven.restlet.org</id>
             <name>maven.restlet.org</name>
-            <url>https://maven.restlet.org</url>
+            <url>https://maven.restlet.talend.com</url>
         </repository>
     </repositories>
 
@@ -29,12 +34,12 @@
         <dependency>
             <groupId>net.sf.saxon</groupId>
             <artifactId>Saxon-HE</artifactId>
-            <version>10.8</version>
+            <version>11.4</version>
         </dependency>
         <dependency>
             <groupId>com.xmlcalabash</groupId>
             <artifactId>xmlcalabash</artifactId>
-            <version>1.5.1-100</version>
+            <version>1.5.3-110</version>
         </dependency>
     </dependencies>
 
@@ -43,7 +48,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>


### PR DESCRIPTION
# Committer Notes

This is pulling over workaround as reported in usnistgov/oscal-content#139 with the WIP workaround submodule.

https://github.com/usnistgov/oscal-content/pull/139/commits/26f0fe160932016638575cfafdc55d796d4c6f5b

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~
