### PR TITLE
Schema cleanup and bugfixes

### DIFF
--- a/schema/json/metaschema-datatypes.json
+++ b/schema/json/metaschema-datatypes.json
@@ -6,7 +6,7 @@
   "definitions" : {
     "Base64Datatype": {
       "type": "string",
-      "pattern": "^[0-9A-Za-z+/]+={0,2}$",
+      "pattern": "^[0-9A-Za-z+\/]+={0,2}$",
       "contentEncoding": "base64"
     },
     "BooleanDatatype": {

--- a/schema/json/metaschema-datatypes.json
+++ b/schema/json/metaschema-datatypes.json
@@ -6,7 +6,7 @@
   "definitions" : {
     "Base64Datatype": {
       "type": "string",
-      "pattern": "^[0-9A-Fa-f]+$",
+      "pattern": "^[0-9A-Za-z+/]+={0,2}$",
       "contentEncoding": "base64"
     },
     "BooleanDatatype": {
@@ -32,22 +32,30 @@
     "DayTimeDurationDatatype": {
       "type": "string",
       "format": "duration",
-      "pattern": "^[-+]?P([-+]?[0-9]+D)?(T([-+]?[0-9]+H)?([-+]?[0-9]+M)?([-+]?[0-9]+([.,][0-9]{0,9})?S)?)?$"
+      "pattern": "^-?P([0-9]+D(T(([0-9]+H([0-9]+M)?(([0-9]+|[0-9]+(\\.[0-9]+)?)S)?)|([0-9]+M(([0-9]+|[0-9]+(\\.[0-9]+)?)S)?)|([0-9]+|[0-9]+(\\.[0-9]+)?)S))?)|T(([0-9]+H([0-9]+M)?(([0-9]+|[0-9]+(\\.[0-9]+)?)S)?)|([0-9]+M(([0-9]+|[0-9]+(\\.[0-9]+)?)S)?)|([0-9]+|[0-9]+(\\.[0-9]+)?)S)$"
     },
     "DecimalDatatype": {
       "type": "number",
       "pattern": "^(\\+|-)?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)$"
     },
     "EmailAddressDatatype": {
-      "type": "string",
-      "format": "email",
-      "pattern": "^.+@.+$"
+      "allOf": [
+        {"$ref": "#/definitions/StringDatatype"},
+        {
+          "type": "string",
+          "format": "email",
+          "pattern": "^.+@.+$"
+        }
+      ]
     },
     "HostnameDatatype": {
-           "allOf": [
-           {"$ref": "#/definitions/StringDatatype"},
-           {"format": "idn-hostname"}
-       ]     
+      "allOf": [
+        {"$ref": "#/definitions/StringDatatype"},
+        {
+          "type": "string",
+          "format": "idn-hostname"
+        }
+      ]
     },
     "IntegerDatatype": {
       "type": "integer"
@@ -70,18 +78,22 @@
       "type": "string"
     },
     "NonNegativeIntegerDatatype": {
-       "allOf": [
-           {"$ref": "#/definitions/IntegerDatatype"},
-           {"minimum": 0,
-            "type": "number"}
-       ]
+      "allOf": [
+        {"$ref": "#/definitions/IntegerDatatype"},
+        {
+          "type": "number",
+          "minimum": 0
+        }
+      ]
     },
     "PositiveIntegerDatatype": {
-       "allOf": [
-           {"$ref": "#/definitions/IntegerDatatype"},
-           {"minimum": 1,
-            "type": "number"}
-       ]
+      "allOf": [
+        {"$ref": "#/definitions/IntegerDatatype"},
+        {
+          "type": "number",
+          "minimum": 1
+        }
+      ]
     },
     "StringDatatype": {
       "type": "string",
@@ -108,7 +120,7 @@
     "YearMonthDurationDatatype": {
       "type": "string",
       "format": "duration",
-      "pattern": "^[-+]?P([-+]?[0-9]+Y)?([-+]?[0-9]+M)?([-+]?[0-9]+W)?([-+]?[0-9]+D)?$"
+      "pattern": "^-?P([0-9]+Y([0-9]+M)?)|[0-9]+M$"
     }
   }
 }

--- a/schema/xml/metaschema-datatypes.xsd
+++ b/schema/xml/metaschema-datatypes.xsd
@@ -4,23 +4,13 @@
 
 	<xs:simpleType name="Base64Datatype">
 		<xs:restriction base="xs:base64Binary">
-			<xs:pattern value="\S(.*\S)?">
-				<xs:annotation>
-					<xs:documentation>A trimmed string, at least one character with no
-						leading or trailing whitespace.</xs:documentation>
-				</xs:annotation>
-			</xs:pattern>
+			<xs:pattern value="[0-9A-Za-z+/]+={0,2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	
 	<xs:simpleType name="BooleanDatatype">
 		<xs:restriction base="xs:boolean">
-			<xs:pattern value="\S(.*\S)?">
-				<xs:annotation>
-					<xs:documentation>A trimmed string, at least one character with no
-						leading or trailing whitespace.</xs:documentation>
-				</xs:annotation>
-			</xs:pattern>
+			<xs:pattern value="true|1|false|0"/>
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -56,7 +46,7 @@
 
 	<xs:simpleType name="DayTimeDurationDatatype">
 		<xs:restriction base="xs:duration">
-			<xs:pattern value="[-+]?P([-+]?[0-9]+D)?(T([-+]?[0-9]+H)?([-+]?[0-9]+M)?([-+]?[0-9]+([.,][0-9]{0,9})?S)?)?"/>
+			<xs:pattern value="-?P([0-9]+D(T(([0-9]+H([0-9]+M)?(([0-9]+|[0-9]+(\.[0-9]+)?)S)?)|([0-9]+M(([0-9]+|[0-9]+(\.[0-9]+)?)S)?)|([0-9]+|[0-9]+(\.[0-9]+)?)S))?)|T(([0-9]+H([0-9]+M)?(([0-9]+|[0-9]+(\.[0-9]+)?)S)?)|([0-9]+M(([0-9]+|[0-9]+(\.[0-9]+)?)S)?)|([0-9]+|[0-9]+(\.[0-9]+)?)S)"/>
 		</xs:restriction>
 	</xs:simpleType>
 
@@ -76,7 +66,7 @@
 			<xs:documentation>An email address</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="StringDatatype">
-			<xs:pattern value="\S.*@.*\S">
+			<xs:pattern value=".+@.+">
 				<xs:annotation>
 					<xs:documentation>Need a better pattern.</xs:documentation>
 				</xs:annotation>
@@ -237,5 +227,10 @@
 			</xs:pattern>
 		</xs:restriction>
 	</xs:simpleType>
-</xs:schema>
 
+	<xs:simpleType name="YearMonthDurationDatatype">
+		<xs:restriction base="xs:duration">
+			<xs:pattern value="-?P([0-9]+Y([0-9]+M)?)|[0-9]+M"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -55,14 +55,7 @@
           <xs:element name="define-flag" type="GlobalFlagDefinitionType"/>
         </xs:choice>
       </xs:sequence>
-      <xs:attribute name="abstract">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="yes"/>
-            <xs:enumeration value="no"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
+      <xs:attribute name="abstract" type="YesNoType" default="no"/>
     </xs:complexType>
     <xs:unique name="unique-constraint-ids">
       <xs:selector xpath=".//allowed-values|.//matches|.//index-has-key|.//is-unique|.//has-cardinality|.//expect|.//index"/>


### PR DESCRIPTION
# Committer Notes

This set of changes are to cleanup a variety schemas.

- Fixes a bug in the base64 data type that caused by most of the allowed alphabet to be excluded as well as padding characters.
- Corrected duration-based patterns to enforce the correct semantics.
- Simplified boolean patterns.
- Aligned integer and string data type derivations.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
