### PR TITLE
Relax Schematron Checks

### DIFF
--- a/toolchains/xslt-M4/validate/metaschema-composition-check.sch
+++ b/toolchains/xslt-M4/validate/metaschema-composition-check.sch
@@ -220,8 +220,8 @@
         </sch:rule>
 
         <sch:rule context="m:description">
-            <sch:assert role="error" test="ends-with(.,'.')" id="description-ends-with-dot">Description should end with a period.</sch:assert>
-            <sch:assert role="error" test="string-length(.) gt 6" id="description-long-enough">Description is too short.</sch:assert>
+            <sch:assert role="warning" test="ends-with(.,'.')" id="description-ends-with-dot">Description should end with a period.</sch:assert>
+            <sch:assert role="warning" test="string-length(.) gt 6" id="description-long-enough">Description is too short.</sch:assert>
         </sch:rule>
     </sch:pattern>
     


### PR DESCRIPTION
# Committer Notes

To allow for backporting certain metaschemas for an upstream OSCAL release drafted before these Schematron rules were added, make them warnings and not errors, so they do not fail CI/CD. Also this way we discourage time travel.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
