### PR TITLE
Use `anyOf` when `@allow-other = 'yes'` in JSON Schema

### DIFF
--- a/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
+++ b/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
@@ -194,6 +194,16 @@
             <xsl:apply-templates select="$decl/constraint/allowed-values"/>
         </xsl:variable>
         <xsl:choose>
+            <xsl:when test="exists($enumerations) and $decl/constraint/allowed-values/@allow-other = 'yes'">
+                <array key="anyOf">
+                    <map>
+                        <xsl:apply-templates select="." mode="object-type"/>
+                    </map>
+                    <map>
+                        <xsl:sequence select="$enumerations"/>
+                    </map>
+                </array>
+            </xsl:when>
             <xsl:when test="exists($enumerations)">
                 <array key="allOf">
                     <map>

--- a/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
+++ b/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
@@ -196,7 +196,8 @@
         <xsl:variable name="allow-other" select="$enumerations/@allow-other = 'yes'"/>
         <xsl:variable name="any-or-all" select="if ($allow-other) then 'anyOf' else 'allOf'"/> 
         <xsl:choose>
-            <xsl:when test="exists($enumerations)">
+
+            <xsl:when test="exists($enumerations) and (constraint/allowed-values/@target = '.' or empty(constraint/allowed-values/@target))">
                 <array key="{$any-or-all}">
                     <map>
                         <xsl:apply-templates select="." mode="object-type"/>

--- a/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
+++ b/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl
@@ -193,19 +193,11 @@
         <xsl:variable name="enumerations" as="node()*">
             <xsl:apply-templates select="$decl/constraint/allowed-values"/>
         </xsl:variable>
+        <xsl:variable name="allow-other" select="$enumerations/@allow-other = 'yes'"/>
+        <xsl:variable name="any-or-all" select="if ($allow-other) then 'anyOf' else 'allOf'"/> 
         <xsl:choose>
-            <xsl:when test="exists($enumerations) and $decl/constraint/allowed-values/@allow-other = 'yes'">
-                <array key="anyOf">
-                    <map>
-                        <xsl:apply-templates select="." mode="object-type"/>
-                    </map>
-                    <map>
-                        <xsl:sequence select="$enumerations"/>
-                    </map>
-                </array>
-            </xsl:when>
             <xsl:when test="exists($enumerations)">
-                <array key="allOf">
+                <array key="{$any-or-all}">
                     <map>
                         <xsl:apply-templates select="." mode="object-type"/>
                     </map>


### PR DESCRIPTION
# Committer Notes

When there is a type and an enumeration in JSON Schema, using `allOf`
means that a value must satisfy _both_ types. This is appropriate when
`@allow-other = 'no'` because it effectively limits the permitted values
to the enumeration; however, when `@allow-other = 'yes'`, that
limitation means that you are not able to use 'locally defined' values.
In this case, `anyOf` is preferable, this allows values in the
enumeration and otherwise any value that matches the schema for the
type.

A check is added explicitly for `@allow-other = 'yes'` as
`@allow-other = 'no'` is the default and matches the existing behavior.

This follows the pattern used in #253.

https://github.com/usnistgov/metaschema/blob/70085548fec75de999eebb480a0be7d7b1abdada/toolchains/xslt-M4/schema-gen/make-json-schema-metamap.xsl#L328-L352

Closes: usnistgov/OSCAL#1773

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~Have you written new tests for your core changes, as applicable?~ @aj-stein-nist will do this in a follow-on PR
- ~Have you included examples of how to use your new feature(s)?~
- ~Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~
