### PR TITLE
Generate anchors

### DIFF
--- a/toolchains/xslt-M4/document/json/object-reference-html.xsl
+++ b/toolchains/xslt-M4/document/json/object-reference-html.xsl
@@ -62,15 +62,21 @@
       <div class="model-entry definition { tokenize($me/@_metaschema-json-id,'/')[2] }">
          <xsl:variable name="header-class" expand-text="true">{ if (exists(parent::map)) then 'definition' else 'instance' }-header</xsl:variable>
          <div class="{ $header-class }">
-            <!-- ===!!! generates h1-hx headers picked up by Hugo toc !!!=== -->
+            <!-- 
+               Generate the proper class attribute to match a given HTML header from $header-tag (h1, h2,...h6) 
+               to define the proper corresponding style (toc1, toc2,... toc6) as bound by toc{ $level } in Hugo.
+
+               This build-time generation of anchor from template improves performance of website at load time 
+               and decreases page "time to responsiveness" in the browser.
+            -->
             <xsl:element name="a" namespace="http://www.w3.org/1999/xhtml">
                <xsl:attribute name="href">#{@_tree-json-id}</xsl:attribute>
-               <xsl:attribute name="class">no-anchor-xslt toc{$level} name</xsl:attribute>
+               <xsl:attribute name="class">reference-element-anchor toc{$level} name </xsl:attribute>
                <xsl:attribute name="title">Focus on {@key} details</xsl:attribute>
 
                <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
                   <xsl:attribute name="id" select="@_tree-json-id"/>
-                  <xsl:attribute name="class">no-anchor-xslt toc{$level} name </xsl:attribute>
+                  <xsl:attribute name="class">reference-element-anchor toc{$level} name </xsl:attribute>
                   <xsl:text>{ @key }</xsl:text>
                </xsl:element>
 

--- a/toolchains/xslt-M4/document/json/object-reference-html.xsl
+++ b/toolchains/xslt-M4/document/json/object-reference-html.xsl
@@ -64,7 +64,6 @@
          <div class="{ $header-class }">
             <!-- ===!!! generates h1-hx headers picked up by Hugo toc !!!=== -->
             <xsl:element name="a" namespace="http://www.w3.org/1999/xhtml">
-
                <xsl:attribute name="href">#{@_tree-json-id}</xsl:attribute>
                <xsl:attribute name="class">no-anchor-xslt toc{$level} name</xsl:attribute>
                <xsl:attribute name="title">Focus on {@key} details</xsl:attribute>

--- a/toolchains/xslt-M4/document/json/object-reference-html.xsl
+++ b/toolchains/xslt-M4/document/json/object-reference-html.xsl
@@ -58,15 +58,28 @@
       <xsl:variable name="header-tag" select="if ($level le 6) then ('h' || $level) else 'p'"/>
       <xsl:variable name="grouped-object" select="(self::array | self::singleton-or-array)/*"/>
       <xsl:variable name="me" select="($grouped-object,.)[1]"/>
+
       <div class="model-entry definition { tokenize($me/@_metaschema-json-id,'/')[2] }">
          <xsl:variable name="header-class" expand-text="true">{ if (exists(parent::map)) then 'definition' else 'instance' }-header</xsl:variable>
          <div class="{ $header-class }">
-            <!-- generates h1-hx headers picked up by Hugo toc -->
-            <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
-               <xsl:attribute name="id" select="@_tree-json-id"/>
-               <xsl:attribute name="class">toc{ $level} name</xsl:attribute>
-               <xsl:text>{ @key }</xsl:text>
+            <!-- ===!!! generates h1-hx headers picked up by Hugo toc !!!=== -->
+
+            <!-- ===!!! Anchor hard wrap-around of Headers 1-6 [see logic above with ($level le 6)] !!!=== -->               
+            <xsl:element expand-text="true" name="a" namespace="http://www.w3.org/1999/xhtml">
+
+               <xsl:attribute name="href">#{@_tree-json-id}</xsl:attribute>
+               <xsl:attribute name="class">no-anchor-xslt Obj-Ref-Html--Xsl-71 toc{$level} name</xsl:attribute>
+               <xsl:attribute name="title">Focus on {@key} details</xsl:attribute>
+
+               <!-- ===!!! The Headers 1-6 that are being wrapped around !!!=== --> 
+               <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
+                  <xsl:attribute name="id" select="@_tree-json-id"/>
+                  <xsl:attribute name="class">no-anchor-xslt toc{$level} name </xsl:attribute>
+                  <xsl:text>{ @key }</xsl:text>
+               </xsl:element>
+
             </xsl:element>
+
             <p class="type">
                <xsl:apply-templates select="." mode="metaschema-type"/>
             </p>

--- a/toolchains/xslt-M4/document/json/object-reference-html.xsl
+++ b/toolchains/xslt-M4/document/json/object-reference-html.xsl
@@ -63,15 +63,12 @@
          <xsl:variable name="header-class" expand-text="true">{ if (exists(parent::map)) then 'definition' else 'instance' }-header</xsl:variable>
          <div class="{ $header-class }">
             <!-- ===!!! generates h1-hx headers picked up by Hugo toc !!!=== -->
-
-            <!-- ===!!! Anchor hard wrap-around of Headers 1-6 [see logic above with ($level le 6)] !!!=== -->               
-            <xsl:element expand-text="true" name="a" namespace="http://www.w3.org/1999/xhtml">
+            <xsl:element name="a" namespace="http://www.w3.org/1999/xhtml">
 
                <xsl:attribute name="href">#{@_tree-json-id}</xsl:attribute>
-               <xsl:attribute name="class">no-anchor-xslt Obj-Ref-Html--Xsl-71 toc{$level} name</xsl:attribute>
+               <xsl:attribute name="class">no-anchor-xslt toc{$level} name</xsl:attribute>
                <xsl:attribute name="title">Focus on {@key} details</xsl:attribute>
 
-               <!-- ===!!! The Headers 1-6 that are being wrapped around !!!=== --> 
                <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
                   <xsl:attribute name="id" select="@_tree-json-id"/>
                   <xsl:attribute name="class">no-anchor-xslt toc{$level} name </xsl:attribute>

--- a/toolchains/xslt-M4/document/xml/element-reference-html.xsl
+++ b/toolchains/xslt-M4/document/xml/element-reference-html.xsl
@@ -56,16 +56,21 @@
       <div class="model-entry definition { tokenize(@_metaschema-xml-id,'/')[2] }">
          <xsl:variable name="header-class" expand-text="true">{ if (exists(parent::map)) then 'definition' else 'instance' }-header</xsl:variable>
          <div class="{ $header-class }">
+            <!-- 
+               Generate the proper class attribute to match a given HTML header from $header-tag (h1, h2,...h6) 
+               to define the proper corresponding style (toc1, toc2,... toc6) as bound by toc{ $level } in Hugo.
 
-            <!-- generates h1-hx headers picked up by Hugo ToC -->
+               This build-time generation of anchor from template improves performance of website at load time 
+               to decrease page time to responsiveness in the browser.
+            -->
             <xsl:element name="a" namespace="http://www.w3.org/1999/xhtml">
                <xsl:attribute name="href">#{@_tree-xml-id}</xsl:attribute>
-               <xsl:attribute name="class">no-anchor-xslt toc{$level} name</xsl:attribute>
+               <xsl:attribute name="class">reference-element-anchor toc{ $level } name </xsl:attribute>
                <xsl:attribute name="title">Focus on {@gi} details</xsl:attribute>
 
                <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
                   <xsl:attribute name="id" select="@_tree-xml-id"/>
-                  <xsl:attribute name="class">no-anchor-xslt toc{ $level} name</xsl:attribute>
+                  <xsl:attribute name="class">reference-element-anchor toc{ $level} name</xsl:attribute>
                   <xsl:text>{ @gi }</xsl:text>
                </xsl:element>
 

--- a/toolchains/xslt-M4/document/xml/element-reference-html.xsl
+++ b/toolchains/xslt-M4/document/xml/element-reference-html.xsl
@@ -58,18 +58,14 @@
          <div class="{ $header-class }">
 
             <!-- generates h1-hx headers picked up by Hugo ToC -->
-
-            <!-- ===!!! Anchor hard wrap-around of Headers 1-6 [see logic above with ($level le 6)] !!!=== -->               
-            <xsl:element expand-text="true" name="a" namespace="http://www.w3.org/1999/xhtml">
-
+            <xsl:element name="a" namespace="http://www.w3.org/1999/xhtml">
                <xsl:attribute name="href">#{@_tree-xml-id}</xsl:attribute>
                <xsl:attribute name="class">no-anchor-xslt toc{$level} name</xsl:attribute>
                <xsl:attribute name="title">Focus on {@gi} details</xsl:attribute>
 
-                  <!-- ===!!! The Headers 1-6 that are being wrapped around !!!=== -->
                <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
                   <xsl:attribute name="id" select="@_tree-xml-id"/>
-                  <xsl:attribute name="class">no-anchor-xslt toc{ $level} name Elem-Ref-Html--Xsl-72</xsl:attribute>
+                  <xsl:attribute name="class">no-anchor-xslt toc{ $level} name</xsl:attribute>
                   <xsl:text>{ @gi }</xsl:text>
                </xsl:element>
 

--- a/toolchains/xslt-M4/document/xml/element-reference-html.xsl
+++ b/toolchains/xslt-M4/document/xml/element-reference-html.xsl
@@ -49,7 +49,7 @@
          <xsl:apply-templates/>
        </div>
    </xsl:template>
-   <!-- The Ancor-Template Generation that supposedly slows down the page response (for ALL MODLES especially) -->
+   <!-- additional build-time generation of anchor from template to improve performance -->
    <xsl:template match="*[exists(@gi)]" expand-text="true">
       <xsl:variable name="level" select="count(ancestor-or-self::*[exists(@gi)])"/>
       <xsl:variable name="header-tag" select="if ($level le 6) then ('h' || $level) else 'p'"/>
@@ -139,10 +139,10 @@
          <div class="{ $header-class }">
             <!-- generates h1-hx headers picked up by Hugo toc -->
 
-            <!-- ===!!! Anchor hard wrap-around of Headers 1-6 [see logic above with ($level le 6)] !!!=== -->               
+   <!-- additional build-time generation of anchor from template to improve performance -->
             <xsl:element expand-text="true" name="a" namespace="http://www.w3.org/1999/xhtml">
                <xsl:attribute name="href">#{@_tree-xml-id}</xsl:attribute>
-               <xsl:attribute name="class">anchor-xslt toc{ $level} name  Elem-Ref-Html--Xsl</xsl:attribute>
+               <xsl:attribute name="class">reference-element-anchor toc{ $level} name</xsl:attribute>
                <xsl:attribute name="title">Get {@_tree-xml-id} details</xsl:attribute>
 
                <!-- ===!!! The Headers 1-6 that are being wrapped around !!!=== --> 

--- a/toolchains/xslt-M4/document/xml/element-reference-html.xsl
+++ b/toolchains/xslt-M4/document/xml/element-reference-html.xsl
@@ -49,19 +49,32 @@
          <xsl:apply-templates/>
        </div>
    </xsl:template>
-   
+   <!-- The Ancor-Template Generation that supposedly slows down the page response (for ALL MODLES especially) -->
    <xsl:template match="*[exists(@gi)]" expand-text="true">
       <xsl:variable name="level" select="count(ancestor-or-self::*[exists(@gi)])"/>
       <xsl:variable name="header-tag" select="if ($level le 6) then ('h' || $level) else 'p'"/>
       <div class="model-entry definition { tokenize(@_metaschema-xml-id,'/')[2] }">
          <xsl:variable name="header-class" expand-text="true">{ if (exists(parent::map)) then 'definition' else 'instance' }-header</xsl:variable>
          <div class="{ $header-class }">
-            <!-- generates h1-hx headers picked up by Hugo toc -->
-            <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
-               <xsl:attribute name="id" select="@_tree-xml-id"/>
-               <xsl:attribute name="class">toc{ $level} name</xsl:attribute>
-               <xsl:text>{ @gi }</xsl:text>
+
+            <!-- generates h1-hx headers picked up by Hugo ToC -->
+
+            <!-- ===!!! Anchor hard wrap-around of Headers 1-6 [see logic above with ($level le 6)] !!!=== -->               
+            <xsl:element expand-text="true" name="a" namespace="http://www.w3.org/1999/xhtml">
+
+               <xsl:attribute name="href">#{@_tree-xml-id}</xsl:attribute>
+               <xsl:attribute name="class">no-anchor-xslt toc{$level} name</xsl:attribute>
+               <xsl:attribute name="title">Focus on {@gi} details</xsl:attribute>
+
+                  <!-- ===!!! The Headers 1-6 that are being wrapped around !!!=== -->
+               <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
+                  <xsl:attribute name="id" select="@_tree-xml-id"/>
+                  <xsl:attribute name="class">no-anchor-xslt toc{ $level} name Elem-Ref-Html--Xsl-72</xsl:attribute>
+                  <xsl:text>{ @gi }</xsl:text>
+               </xsl:element>
+
             </xsl:element>
+
             <!-- Only assign the @id here if there is a value and the type is not markup-multiline, since in the other cases it
                  is assigned to the header in the containing div -->
             <p class="type">
@@ -124,10 +137,19 @@
          <xsl:variable name="header-class" expand-text="true">{ if (exists(parent::map)) then 'definition' else 'instance' }-header</xsl:variable>
          <div class="{ $header-class }">
             <!-- generates h1-hx headers picked up by Hugo toc -->
-            <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
-               <xsl:attribute name="id" select="@_tree-xml-id"/>
-               <xsl:attribute name="class">toc{ $level} name</xsl:attribute>
-               <xsl:text>(unwrapped)</xsl:text>
+
+            <!-- ===!!! Anchor hard wrap-around of Headers 1-6 [see logic above with ($level le 6)] !!!=== -->               
+            <xsl:element expand-text="true" name="a" namespace="http://www.w3.org/1999/xhtml">
+               <xsl:attribute name="href">#{@_tree-xml-id}</xsl:attribute>
+               <xsl:attribute name="class">anchor-xslt toc{ $level} name  Elem-Ref-Html--Xsl</xsl:attribute>
+               <xsl:attribute name="title">Get {@_tree-xml-id} details</xsl:attribute>
+
+               <!-- ===!!! The Headers 1-6 that are being wrapped around !!!=== --> 
+               <xsl:element expand-text="true" name="{ $header-tag }" namespace="http://www.w3.org/1999/xhtml">
+                  <xsl:attribute name="id" select="@_tree-xml-id" />
+                  <xsl:attribute name="class">toc{ $level} name </xsl:attribute>
+                  <xsl:text>(unwrapped)               </xsl:text>
+               </xsl:element>
             </xsl:element>
             <p class="type">
                <xsl:apply-templates select="." mode="metaschema-type"/>


### PR DESCRIPTION
# Committer Notes 
Mostly fixes usnistgov/oscal#1681

Added transformations to build in anchors for deep-linking the h1-h6. This part of the Fix spread over repos. The second part is in foot.html and schema-docs.scss

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
