### PR TITLE
Prevent error in converter output when using JSON parameter

### DIFF
--- a/toolchains/xslt-M4/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
+++ b/toolchains/xslt-M4/nist-metaschema-MAKE-JSON-TO-XML-CONVERTER.xsl
@@ -177,7 +177,7 @@
   
 <!--  -->
     <XSLT:template name="from-json">
-      <XSLT:if test="not(unparsed-text-available($file))" expand-text="true">
+      <XSLT:if test="matches($file, '\S') and not(unparsed-text-available($file))" expand-text="true">
         <nm:ERROR>No file found at { $file }</nm:ERROR>
       </XSLT:if>
       <XSLT:variable name="source">


### PR DESCRIPTION
Previously, if `file` was not specified (and `json` was), an error would
be emitted about the file not being found. This was erroneous as only
the JSON input should have been considered. This applies a small fix to
remediate that, given by Wendell in usnistgov/OSCAL#1849.

I am unsure whether this is the desired long-term fix but I figured
opening a PR to memorialize the patch may be useful.

Co-authored-by: Wendell Piez <wendell.piez@nist.gov>

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
