### PR TITLE
Remove support for `@collapisble`

### DIFF
--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -283,7 +283,6 @@
       <xs:element name="example" type="ExampleType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
     <xs:attributeGroup ref="FieldValueAttributeGroup"/>
-    <xs:attribute name="collapsible" type="YesNoType" default="no"/>
     <xs:attribute name="name" use="required" type="ModelNameType"/>
     <xs:attribute name="scope" type="ScopeType" default="global"/>
     <xs:attributeGroup ref="DeprecationAttributeGroup"/>

--- a/test-suite/schema-generation/unit-tests.xml
+++ b/test-suite/schema-generation/unit-tests.xml
@@ -24,20 +24,6 @@
             <validation-case source-format="JSON" location="choice-multiple_test_multiple_PASS.json"/>
         </test-scenario>
     </test-collection>
-    <test-collection name="Feature: Collapsible" location="collapsible/">
-        <test-scenario name="NoOp">
-            <generate-schema>
-                <metaschema location="collapsible-no-op_metaschema.xml"/>
-            </generate-schema>
-        </test-scenario>
-        <test-scenario name="Simple">
-            <generate-schema>
-                <metaschema location="collapsible_metaschema.xml"/>
-            </generate-schema>
-            <validation-case source-format="JSON" location="collapsible_test_multiple_PASS.json"/>
-            <validation-case source-format="JSON" location="collapsible_test_singleton_PASS.json"/>
-        </test-scenario>
-    </test-collection>
     <test-collection name="Feature: Datatype" location="datatypes/">
         <test-scenario name="Character Strings">
             <generate-schema>


### PR DESCRIPTION
# Committer Notes

This PR removes support for `@collapisble`. Which is a seldom used and hated by implementers.

Resolves #354.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
