### PR TITLE
Fix markdown-link-check config path

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -14,7 +14,7 @@ on:
       markdownLinkCheckConfig:
         description: 'the path to the markdown link check config file'
         required: false
-        default: 'build/config/.markdown-link-check/config.json'
+        default: '.github/workflows/config/.markdown-link-check/config.json'
         type: string
       site_git_ref:
         description: 'git ref, a SHA commit or branch or tag, for the published HTML content'


### PR DESCRIPTION
# Committer Notes

Fix MLC config path to unbreak CI. Closes #464.

Tested manually overriding the incorrect default [in this run with workflow-dispatch and putting the same path as that of the PR](https://github.com/usnistgov/metaschema/actions/runs/6538655721).

Will also take care of the following issues:

Closes #461 
Closes #460
Closes #458 
Closes #457 
Closes #455 
Closes #453
Closes #451 
Closes #449
Closes #448 
Closes #446
Closes #445 
Closes #443 
Closes #441
Closes #440 
Closes #439
Closes #438
Closes #437 
Closes #436

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? The original bug report includes a RCA description and a rationale for the bug fix.
- ~Have you written new tests for your core changes, as applicable?  N/A, this is fixing up CI automation for link checking and development cycles on this change does not warrant test.
- ~Have you included examples of how to use your new feature(s)?~ N/A, this is fixing up CI automation for link checking and development cycles on this change does not warrant examples.
- ~Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.~ N/A, this CI code targets Markdown pages in the repo, not the website.
