### PR TITLE
Support for Let Expressions

### DIFF
--- a/examples/computer-example.xml
+++ b/examples/computer-example.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../../../schema/xml/metaschema.xsd"
+ xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../schema/xml/metaschema.xsd"
  xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
     <schema-name>Computer Model</schema-name>
     <schema-version>0.0.5</schema-version>

--- a/schema/xml/metaschema-markup-line.xsd
+++ b/schema/xml/metaschema-markup-line.xsd
@@ -3,7 +3,6 @@
   
   <xs:include schemaLocation="metaschema-prose-base.xsd"/>
 
-
   <xs:complexType name="MarkupLineDatatype" mixed="true">
     <xs:complexContent>
       <xs:extension base="inlineMarkupType"/>

--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -129,10 +129,13 @@
         <prop name="identifier-type" value="human-oriented"/>
         
         Multiple instances of "identifier-type" can be used to support both cases.
+
         TODO: Need to update the documentation to clarify that the value set is constrained and what the options are.
+
         The "identifier-scope" must be one of:
         <prop name="identifier-reference-scope" value="instance"/>
         <prop name="identifier-reference-scope" value="cross-instance"/>
+
         Must be one of:
         <prop namespace="http://csrc.nist.gov/ns/oscal" name="identifier-reference-model" value="model-name"/>
      -->       
@@ -193,20 +196,20 @@
     </xs:sequence>
   </xs:group>
 
+  <xs:complexType name="UseNameType">
+    <xs:simpleContent>
+      <xs:extension base="ModelNameType">
+        <xs:attribute name="index" use="optional" type="ModelIndexType"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
   <xs:group name="UseNamingGroup">
     <xs:annotation>
       <xs:documentation>Common definition attributes that support instance naming.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
-      <xs:element name="use-name" minOccurs="0">
-        <xs:complexType>
-          <xs:simpleContent>
-            <xs:extension base="ModelNameType">
-              <xs:attribute name="index" use="optional" type="ModelIndexType"/>
-            </xs:extension>
-          </xs:simpleContent>
-        </xs:complexType>
-      </xs:element>
+      <xs:element name="use-name" type="UseNameType" minOccurs="0"/>
     </xs:sequence>
   </xs:group>
 
@@ -224,8 +227,7 @@
       <xs:element name="json-key" type="JsonKeyType" minOccurs="0"/>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="flag" type="FlagReferenceType"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" name="define-flag"
-          type="InlineFlagDefinitionType"/>
+        <xs:element name="define-flag" type="InlineFlagDefinitionType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:choice>
       <xs:element name="model" type="AssemblyModelType" minOccurs="0"/>
       <xs:element name="constraint" type="DefineAssemblyConstraintsType" minOccurs="0"/>
@@ -249,7 +251,6 @@
       <xs:element name="any" type="AnyType" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
-
 
   <xs:group name="JsonValueKeyChoiceGroup">
     <xs:sequence>
@@ -474,6 +475,7 @@
           in XML.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="default" type="StringDatatype"/>
     <xs:attributeGroup ref="DeprecationAttributeGroup"/>
   </xs:complexType>
 
@@ -547,6 +549,7 @@
     </xs:sequence>
     <xs:attributeGroup ref="DefinitionReferenceNamingGroup"/>
     <xs:attribute name="required" type="YesNoType" default="no"/>
+    <xs:attribute name="default" type="StringDatatype"/>
     <xs:attributeGroup ref="DeprecationAttributeGroup"/>
   </xs:complexType>
 
@@ -580,7 +583,7 @@
         <xs:any namespace="##other" processContents="lax"/>
       </xs:choice>
     </xs:sequence>
-    <xs:attribute name="href" type="URIDatatype"/>
+    <xs:attribute name="href" type="URIReferenceDatatype"/>
     <xs:attribute name="path" type="StringDatatype"/>
   </xs:complexType>
 
@@ -588,8 +591,7 @@
     <xs:annotation>
       <xs:documentation>In the XML, produces an attribute with the given name, whose value is used as a key value (aka object property name) in the JSON, enabling objects to be 'lifted' out of arrays when such values are distinct. Implies that siblings will never share values.</xs:documentation>
     </xs:annotation>
-    <xs:attribute name="flag-ref" type="ModelNameType"/>
-    <!-- do not have to flag if required; it always will be <xs:attribute name="required" type="xs:NCName"/>-->
+    <xs:attribute name="flag-ref" type="ModelNameType" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="GroupAsType">

--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -1044,8 +1044,27 @@
     </xs:complexContent>
   </xs:complexType>
 
+  <xs:complexType name="ConstraintLetType">
+    <xs:sequence>
+      <xs:group ref="ConstraintContentsGroup"/>
+    </xs:sequence>
+    <xs:attribute name="var" type="TokenDatatype" use="required"/>
+    <xs:attribute name="expression" type="MetaschemaPathType" use="required"/>
+  </xs:complexType>
+
+  <xs:group name="LetExpressionGroup">
+    <xs:sequence>
+      <xs:element name="let" type="ConstraintLetType" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Declares a variable whose name is bound to the result of the Metapath expression. These variables can be used in target and other Metapath expressions used in constrains that are declared in the same context or in constraints declared in a child assembly, field, or flag.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:group>
+
   <xs:complexType name="DefineFlagConstraintsType">
     <xs:sequence>
+      <xs:group ref="LetExpressionGroup"/>
       <xs:choice maxOccurs="unbounded">
         <xs:element minOccurs="0" name="allowed-values" type="AllowedValuesType">
           <xs:annotation>
@@ -1119,6 +1138,7 @@
 
   <xs:complexType name="DefineFieldConstraintsType">
     <xs:sequence>
+      <xs:group ref="LetExpressionGroup"/>
       <xs:choice minOccurs="1" maxOccurs="unbounded">
         <xs:group ref="TargetedCommonConstraintsGroup"/>
       </xs:choice>
@@ -1128,6 +1148,7 @@
 
   <xs:complexType name="DefineAssemblyConstraintsType">
     <xs:sequence>
+      <xs:group ref="LetExpressionGroup"/>
       <xs:choice minOccurs="1" maxOccurs="unbounded">
         <xs:group ref="TargetedCommonConstraintsGroup"/>
         <xs:group ref="AssemblyConstraintsGroup"/>

--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -69,80 +69,9 @@
 -->
   </xs:element>
 
-  <xs:element name="METASCHEMA-CONSTRAINTS">
-    <xs:annotation>
-      <xs:documentation>Root element of a Metaschema external constraints definition. Defines rules to be applied to an existing set of Metaschema models.</xs:documentation>
-    </xs:annotation>
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element name="name" type="StringDatatype">
-          <xs:annotation>
-            <xs:documentation>The name of this constraint set.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-        <xs:element name="version" type="VersionType">
-          <xs:annotation>
-            <xs:documentation>The version of this constraint set.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-
-        <xs:element name="import" minOccurs="0" maxOccurs="unbounded">
-          <xs:annotation>
-            <xs:documentation>To import a set of Metaschema constraints from an out-of-line resource, supporting composition of constraint sets.</xs:documentation>
-          </xs:annotation>
-          <xs:complexType>
-            <xs:attribute name="href" type="URIReferenceDatatype" use="required">
-              <xs:annotation>
-                <xs:documentation>A relative or absolute URI for retrieving an out-of-line Metaschema definition.</xs:documentation>
-              </xs:annotation>
-            </xs:attribute>
-          </xs:complexType>
-        </xs:element>
-
-        <xs:element name="scope" maxOccurs="unbounded">
-          <xs:complexType>
-            <xs:choice maxOccurs="unbounded">
-              <xs:element name="assembly">
-                <xs:complexType>
-                  <xs:complexContent>
-                    <xs:extension base="DefineAssemblyConstraintsType">
-                      <xs:attribute name="target" type="MetaschemaPathType" use="required"/>
-                    </xs:extension>
-                  </xs:complexContent>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="field">
-                <xs:complexType>
-                  <xs:complexContent>
-                    <xs:extension base="DefineFieldConstraintsType">
-                      <xs:attribute name="target" type="MetaschemaPathType" use="required"/>
-                    </xs:extension>
-                  </xs:complexContent>
-                </xs:complexType>
-              </xs:element>
-              <xs:element name="flag">
-                <xs:complexType>
-                  <xs:complexContent>
-                    <xs:extension base="DefineFlagConstraintsType">
-                      <xs:attribute name="target" type="MetaschemaPathType" use="required"/>
-                    </xs:extension>
-                  </xs:complexContent>
-                </xs:complexType>
-              </xs:element>
-            </xs:choice>
-            <xs:attribute name="metaschema-namespace" type="URIDatatype" use="required"/>
-            <xs:attribute name="metaschema-short-name" type="ShortNameType" use="required"/>
-          </xs:complexType>
-        </xs:element>
-
-        <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-
   <xs:complexType name="MetaschemaImportType">
     <xs:annotation>
-      <xs:documentation>Imports a set of Metaschema definitions from an out-of-line resource, supporting reuse of common information structures.</xs:documentation>
+      <xs:documentation>Imports a set of Metaschema modules containing exported definitions from an out-of-line resource, supporting reuse of common information structures.</xs:documentation>
     </xs:annotation>
     <xs:attribute name="href" type="URIReferenceDatatype" use="required">
       <xs:annotation>
@@ -153,10 +82,17 @@
 
   <xs:group name="DefinitionMetadataGroup">
     <xs:sequence>
-      <xs:element name="formal-name" type="FormalNameType" minOccurs="0"/>
+      <xs:element name="formal-name" minOccurs="0">
+        <xs:simpleType>
+          <xs:annotation>
+            <xs:documentation>A formal name for the data construct for use in documentation.</xs:documentation>
+          </xs:annotation>
+          <xs:restriction base="StringDatatype"/>
+        </xs:simpleType>
+      </xs:element>
       <xs:element name="description" type="MarkupLineDatatype" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>A short description of the data construct that provides basic documentation of the construct's purpose.</xs:documentation>
+          <xs:documentation>A short semantic description of the data construct's purpose.</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="prop" type="PropertyType" minOccurs="0" maxOccurs="unbounded"/>
@@ -184,6 +120,22 @@
         <prop name="identifier-persistence" value="per-subject"/>
         <prop name="identifier-persistence" value="change-on-write"/>
      -->
+     <!--
+        When using:
+        <prop name="value-type" value="identifier-reference"/>
+
+        The "identifier-type" must be one of:
+        <prop name="identifier-type" value="machine-oriented"/>
+        <prop name="identifier-type" value="human-oriented"/>
+        
+        Multiple instances of "identifier-type" can be used to support both cases.
+        TODO: Need to update the documentation to clarify that the value set is constrained and what the options are.
+        The "identifier-scope" must be one of:
+        <prop name="identifier-reference-scope" value="instance"/>
+        <prop name="identifier-reference-scope" value="cross-instance"/>
+        Must be one of:
+        <prop namespace="http://csrc.nist.gov/ns/oscal" name="identifier-reference-model" value="model-name"/>
+     -->       
     </xs:sequence>
   </xs:group>
 
@@ -216,6 +168,14 @@
     <xs:attribute name="index" use="optional" type="ModelIndexType"/>
   </xs:attributeGroup>
 
+  <xs:attributeGroup name="DefinitionReferenceNamingGroup">
+    <xs:annotation>
+      <xs:documentation>Common definition attributes that support definition referencing.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="ref" use="required" type="ModelNameType"/>
+    <xs:attribute name="index" use="optional" type="ModelIndexType"/>
+  </xs:attributeGroup>
+
   <xs:group name="RootDefinitionNamingGroup">
     <xs:annotation>
       <xs:documentation>Common definition attributes that support root definition naming.</xs:documentation>
@@ -232,7 +192,6 @@
       </xs:element>
     </xs:sequence>
   </xs:group>
-
 
   <xs:group name="UseNamingGroup">
     <xs:annotation>
@@ -268,8 +227,8 @@
         <xs:element minOccurs="0" maxOccurs="unbounded" name="define-flag"
           type="InlineFlagDefinitionType"/>
       </xs:choice>
-      <xs:element name="model" minOccurs="0" type="AssemblyModelType"/>
-      <xs:element minOccurs="0" name="constraint" type="DefineAssemblyConstraintsType"/>
+      <xs:element name="model" type="AssemblyModelType" minOccurs="0"/>
+      <xs:element name="constraint" type="DefineAssemblyConstraintsType" minOccurs="0"/>
       <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
       <xs:element name="example" type="ExampleType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
@@ -327,8 +286,7 @@
       <xs:group ref="JsonValueKeyChoiceGroup"/>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="flag" type="FlagReferenceType"/>
-        <xs:element name="define-flag" type="InlineFlagDefinitionType" minOccurs="0"
-          maxOccurs="unbounded"/>
+        <xs:element name="define-flag" type="InlineFlagDefinitionType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:choice>
       <xs:element name="constraint" type="DefineFieldConstraintsType" minOccurs="0"/>
       <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
@@ -339,7 +297,6 @@
     <xs:attribute name="scope" type="ScopeType" default="global"/>
     <xs:attributeGroup ref="DeprecationAttributeGroup"/>
   </xs:complexType>
-
 
   <xs:complexType name="GlobalFlagDefinitionType">
     <xs:annotation>
@@ -373,11 +330,10 @@
       <xs:element name="group-as" type="GroupAsType" minOccurs="0"/>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="flag" type="FlagReferenceType"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" name="define-flag"
-          type="InlineFlagDefinitionType"/>
+        <xs:element name="define-flag" type="InlineFlagDefinitionType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:choice>
-      <xs:element name="model" minOccurs="0" type="AssemblyModelType"/>
-      <xs:element minOccurs="0" name="constraint" type="DefineAssemblyConstraintsType"/>
+      <xs:element name="model" type="AssemblyModelType" minOccurs="0"/>
+      <xs:element name="constraint" type="DefineAssemblyConstraintsType" minOccurs="0"/>
       <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
       <xs:element name="example" type="ExampleType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
@@ -390,7 +346,7 @@
     <xs:annotation>
       <xs:documentation>In JSON, an object with a nominal string value (potentially with internal
         inline - not fully structured - markup). In XML, an element with string or markup
-        content. A local definition describes and constrains the appearance of the field only in this (assembly) context.</xs:documentation>
+        content.</xs:documentation>
     </xs:annotation>
     <xs:sequence>
       <xs:group ref="DefinitionMetadataGroup"/>
@@ -399,10 +355,9 @@
       <xs:element name="group-as" type="GroupAsType" minOccurs="0"/>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
         <xs:element name="flag" type="FlagReferenceType"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" name="define-flag"
-          type="InlineFlagDefinitionType"/>
+        <xs:element name="define-flag" type="InlineFlagDefinitionType" minOccurs="0" maxOccurs="unbounded"/>
       </xs:choice>
-      <xs:element minOccurs="0" name="constraint" type="DefineFieldConstraintsType"/>
+      <xs:element name="constraint" type="DefineFieldConstraintsType" minOccurs="0"/>
       <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
       <xs:element name="example" type="ExampleType" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
@@ -412,8 +367,7 @@
     <xs:attributeGroup ref="DefinitionNamingGroup"/>
     <xs:attribute name="in-xml" type="InXmlWrappedType" default="WRAPPED">
       <xs:annotation>
-        <xs:documentation>A field with assigned data type 'markup-multiline' may be designated for representation with or without a containing (wrapper) element
-          in XML.</xs:documentation>
+        <xs:documentation>A field with assigned data type 'markup-multiline' may be designated for representation with or without a containing (wrapper) element in XML.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attributeGroup ref="DeprecationAttributeGroup"/>
@@ -434,13 +388,6 @@
     <xs:attribute name="required" type="YesNoType" default="no"/>
     <xs:attributeGroup ref="DeprecationAttributeGroup"/>
   </xs:complexType>
-
-  <xs:simpleType name="FormalNameType">
-    <xs:annotation>
-      <xs:documentation>A formal name for the data construct, to be presented in documentation.</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="StringDatatype"/>
-  </xs:simpleType>
 
   <xs:simpleType name="JsonBaseUriType">
     <xs:annotation>
@@ -504,7 +451,7 @@
       <xs:element name="group-as" type="GroupAsType" minOccurs="0"/>
       <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
     </xs:sequence>
-    <xs:attribute name="ref" use="required" type="ModelNameType"/>
+    <xs:attributeGroup ref="DefinitionReferenceNamingGroup"/>
     <xs:attributeGroup ref="CardinalitySpecificationGroup"/>
     <xs:attributeGroup ref="DeprecationAttributeGroup"/>
   </xs:complexType>
@@ -519,7 +466,7 @@
       <xs:element name="group-as" type="GroupAsType" minOccurs="0"/>
       <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
     </xs:sequence>
-    <xs:attribute name="ref" use="required" type="ModelNameType"/>
+    <xs:attributeGroup ref="DefinitionReferenceNamingGroup"/>
     <xs:attributeGroup ref="CardinalitySpecificationGroup"/>
     <xs:attribute name="in-xml" type="InXmlWrappedType" default="WRAPPED">
       <xs:annotation>
@@ -584,109 +531,6 @@
     </xs:union>
   </xs:simpleType>
 
-  <xs:complexType abstract="true" name="ConstraintType">
-    <xs:sequence>
-      <xs:group ref="DefinitionMetadataGroup"/>
-    </xs:sequence>
-    <xs:attribute name="id" type="TokenDatatype" use="optional"/>
-    <xs:attribute name="level" type="LevelType" default="ERROR"/>
-  </xs:complexType>
-
-  <xs:group name="ConstraintContentsGroup">
-    <xs:sequence>
-      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
-    </xs:sequence>
-  </xs:group>
-
-  <xs:simpleType name="LevelType">
-    <xs:restriction base="TokenDatatype">
-      <xs:enumeration value="CRITICAL">
-        <xs:annotation>
-          <xs:documentation>A violation of the constraint represents a serious fault in the content
-            that will prevent typical use of the content.</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="ERROR">
-        <xs:annotation>
-          <xs:documentation>A violation of the constraint represents a fault in the content. This
-            may include issues around compatibility, integrity, consistency, etc.</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="WARNING">
-        <xs:annotation>
-          <xs:documentation>A violation of the constraint represents a potential issue
-            with the content.</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="INFORMATIONAL">
-        <xs:annotation>
-          <xs:documentation>A violation of the constraint represents a point of
-            interest.</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-    </xs:restriction>
-  </xs:simpleType>
-
-  <xs:complexType name="AllowedValuesType">
-    <xs:annotation>
-      <xs:documentation>Indicates a set of values to be recognized for a flag or field, with semantics asserted by an enumeration (enum).</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="ConstraintType">
-        <xs:sequence>
-          <xs:element name="enum" type="EnumType" maxOccurs="unbounded"/>
-          <xs:group ref="ConstraintContentsGroup"/>
-        </xs:sequence>
-        <xs:attribute name="allow-other" type="YesNoType" default="no">
-          <xs:annotation>
-            <xs:documentation>The given enumerated value or values are inclusive of other values ('yes') or not ('no', the default)</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="extensible" type="ExtensibleEnumType" default="external">
-          <xs:annotation>
-            <xs:documentation>Determines if the given enumerated value or values within a namespace may be extended by other allowed value constraints.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:simpleType name="ExtensibleEnumType">
-    <xs:restriction base="TokenDatatype">
-      <xs:enumeration value="model">
-        <xs:annotation>
-          <xs:documentation>Can be extended by constraints within the same model.</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="external">
-        <xs:annotation>
-          <xs:documentation>Can be extended by external constraints.</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-      <xs:enumeration value="none">
-        <xs:annotation>
-          <xs:documentation>Cannot be extended.</xs:documentation>
-        </xs:annotation>
-      </xs:enumeration>
-    </xs:restriction>
-  </xs:simpleType>
-
-  <xs:complexType name="EnumType">
-    <xs:annotation>
-      <xs:documentation>An enumerated value for a flag or field. The value is indicated by the 'value' attribute while the element contents describe the intended semantics for documentation.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="MarkupLineDatatype">
-        <xs:attribute name="value" use="required" type="StringDatatype">
-          <xs:annotation>
-            <xs:documentation>A value recognized for a flag or field.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attributeGroup ref="DeprecationAttributeGroup"/>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
   <xs:attributeGroup name="DeprecationAttributeGroup">
     <xs:attribute name="deprecated" type="VersionType">
       <xs:annotation>
@@ -701,367 +545,9 @@
       <xs:group ref="UseNamingGroup"/>
       <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
     </xs:sequence>
-    <xs:attribute name="ref" use="required" type="ModelNameType"/>
+    <xs:attributeGroup ref="DefinitionReferenceNamingGroup"/>
     <xs:attribute name="required" type="YesNoType" default="no"/>
     <xs:attributeGroup ref="DeprecationAttributeGroup"/>
-  </xs:complexType>
-
-  <xs:simpleType name="RegexType">
-    <xs:annotation>
-      <xs:documentation>A regex subset that is conformant to both https://www.w3.org/TR/xmlschema11-2/#regexes and https://www.ecma-international.org/ecma-262/11.0/index.html#sec-patterns.</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="StringDatatype"/>
-  </xs:simpleType>
-
-  <xs:simpleType name="MetaschemaPathType">
-    <xs:restriction base="StringDatatype"/>
-  </xs:simpleType>
-
-  <xs:complexType name="MatchesConstraintType">
-    <!-- TODO: need a metaschema check to make sure either a pattern or a datatype is used; or make these element children and use a choice -->
-    <xs:complexContent>
-      <xs:extension base="ConstraintType">
-        <xs:sequence>
-          <xs:group ref="ConstraintContentsGroup"/>
-        </xs:sequence>
-        <xs:attribute name="regex" type="RegexType"/>
-        <xs:attribute name="datatype" type="SimpleDatatypesType">
-          <xs:annotation>
-            <xs:documentation>Specifies the data type for which the value identified by the scope
-              attribute must conform to.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:complexType name="ScopedMatchesConstraintType">
-    <xs:complexContent>
-      <xs:extension base="MatchesConstraintType">
-        <xs:attribute name="target" type="MetaschemaPathType" use="required">
-          <xs:annotation>
-            <xs:documentation>Specifies the target of the constraint as a Metapath expression. If the value is "." and the containing Metaschema object is a field, the constraint applies to the field's value. Otherwise, the scope value "." is not allowed to be used.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:complexType name="ScopedAllowedValuesType">
-    <xs:complexContent>
-      <xs:extension base="AllowedValuesType">
-        <!-- Not supporting @extends until semantics of application (scope) can be defined - which
-                   constraints (global and local) are extended? 
-                <xs:attribute name="extends" type="boolean" default="yes">
-                <xs:annotation>
-                  <xs:documentation>If <code>yes</code>, indicates that the provided enumerated
-                    values are appended to those defined by the referenced flag. If
-                    <code>no</code>, then the provided enumerated values are used in place of
-                    those defined by the referenced flag/</xs:documentation>
-                </xs:annotation>
-              </xs:attribute>-->
-        <xs:attribute name="target" type="MetaschemaPathType" use="required">
-          <xs:annotation>
-            <xs:documentation>Specifies the target of the constraint as a Metapath expression. If the value is "." and the containing Metaschema object is a field, the constraint applies to the field's value.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:complexType name="DefineFlagConstraintsType">
-    <xs:sequence>
-      <xs:choice maxOccurs="unbounded">
-        <xs:element minOccurs="0" name="allowed-values" type="AllowedValuesType">
-          <xs:annotation>
-            <xs:documentation>Constrains the allowed values for the flag.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-        <xs:element name="matches" type="MatchesConstraintType">
-          <xs:annotation>
-            <xs:documentation>Constrains the allowed values based on the provided regex pattern.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-        <xs:element name="index-has-key" type="IndexHasKeyConstraintType">
-          <xs:annotation>
-            <xs:documentation>Checks that the specified <code>key-field</code> values match a key in the index with the specified <code>name</code>.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-        <xs:element name="expect" type="ExpectConstraintType">
-          <xs:annotation>
-            <xs:documentation>Checks that the specified test returns true in this evaluation context.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-      </xs:choice>
-      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
-    </xs:sequence>
-  </xs:complexType>
-
-  <!--<xs:complexType name="flag-reference-constraints-type">
-    <xs:sequence>
-      <xs:choice>
-        <xs:element name="allowed-values" minOccurs="0">
-          <xs:annotation>
-            <xs:documentation>Constrains the allowed values for the flag.</xs:documentation>
-          </xs:annotation>
-          <xs:complexType>
-            <xs:complexContent>
-              <xs:extension base="allowed-values-type">
-                <xs:attribute name="extends" type="boolean" default="yes">
-                  <xs:annotation>
-                    <xs:documentation>If <code>yes</code>, indicates that the provided enumerated
-                      values are appended to those defined by the referenced flag. If
-                        <code>no</code>, then the provided enumerated values are used in place of
-                      those defined by the referenced flag/</xs:documentation>
-                  </xs:annotation>
-                </xs:attribute>
-              </xs:extension>
-            </xs:complexContent>
-          </xs:complexType>
-        </xs:element>
-        <xs:element name="matches" type="matches-constraint-type">
-          <xs:annotation>
-            <xs:documentation>Constrains the allowed values based on the provided regex pattern.</xs:documentation>
-          </xs:annotation>
-        </xs:element>
-      </xs:choice>
-      <xs:element minOccurs="0" ref="remarks"/>
-    </xs:sequence>
-  </xs:complexType>-->
-
-  <xs:complexType name="IndexFieldType">
-    <xs:sequence>
-      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
-    </xs:sequence>
-    <xs:attribute name="target" type="MetaschemaPathType" use="required">
-      <xs:annotation>
-        <xs:documentation>Specifies the field or flag value that is used to generate the key for a given object that is a member of this index. If more than one key-field is provided, then the key is a composition of the specified key-fields. The ordering of the key-field defined the relative order of the index's key. The field or flag values pointed to must be a field value or a required flag value.</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-  </xs:complexType>
-
-  <xs:complexType name="KeyConstraintType">
-    <xs:annotation>
-      <xs:documentation>Defines an unique key constraint.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="ConstraintType">
-        <xs:sequence>
-          <xs:element name="key-field" maxOccurs="unbounded">
-            <xs:annotation>
-              <xs:documentation>Specifies a value, relative to the provided <code>target</code>,
-                that is to be used as part of the key. More than one key-field can be used to create
-                a composite key.</xs:documentation>
-            </xs:annotation>
-            <xs:complexType>
-              <xs:complexContent>
-                <xs:extension base="IndexFieldType">
-                  <xs:attribute name="pattern" type="RegexType">
-                    <xs:annotation>
-                      <xs:documentation>The first captured group in the regular expression is used
-                        as the key value for lookup. The regular expression must not match a
-                        zero-length string.</xs:documentation>
-                    </xs:annotation>
-                  </xs:attribute>
-                </xs:extension>
-              </xs:complexContent>
-            </xs:complexType>
-          </xs:element>
-          <xs:group ref="ConstraintContentsGroup"/>
-        </xs:sequence>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:complexType name="ScopedKeyConstraintType">
-    <xs:complexContent>
-      <xs:extension base="KeyConstraintType">
-        <xs:attribute name="target" type="MetaschemaPathType" use="required">
-          <xs:annotation>
-            <xs:documentation>Specifies the value objects to be included in the key constraint, or the object that contains a reference to an item in an index. If the value is ".", then the key is targeting the current Metaschema object.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-
-
-  <xs:complexType name="IndexHasKeyConstraintType">
-    <xs:annotation>
-      <xs:documentation>Defines an index, a check against an index, or a uniqueness constraint.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="KeyConstraintType">
-        <xs:attribute name="name" type="ModelNameType" use="required">
-          <xs:annotation>
-            <xs:documentation>Specifies the name of the index, a reference to an index, or the name of a uniqueness constraint.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:complexType name="ScopedIndexHasKeyConstraintType">
-    <xs:annotation>
-      <xs:documentation>Defines an index, a check against an index, or a uniqueness constraint.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="IndexHasKeyConstraintType">
-        <xs:attribute name="target" type="MetaschemaPathType" use="required">
-          <xs:annotation>
-            <xs:documentation>Specifies the value objects to be included in the index constraint, or the object that contains a reference to an item in an index. If the value is ".", then the key is targeting the current Metaschema object.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-
-  <xs:complexType name="ScopedIndexConstraintType">
-    <xs:annotation>
-      <xs:documentation>Defines an index, a check against an index, or a uniqueness constraint.</xs:documentation>
-    </xs:annotation>
-    <xs:complexContent>
-      <xs:extension base="KeyConstraintType">
-        <xs:attribute name="target" type="MetaschemaPathType" use="required">
-          <xs:annotation>
-            <xs:documentation>Specifies the value objects to be included in the index constraint, or the object that contains a reference to an item in an index. If the value is ".", then the key is targeting the current Metaschema object.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="name" type="ModelNameType" use="required">
-          <xs:annotation>
-            <xs:documentation>Specifies the name of the index, a reference to an index, or the name of a uniqueness constraint.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:complexType name="ExpectConstraintType">
-    <xs:complexContent>
-      <xs:extension base="ConstraintType">
-        <xs:sequence>
-          <xs:element name="message" type="StringDatatype" minOccurs="0"/>
-          <xs:group ref="ConstraintContentsGroup"/>
-        </xs:sequence>
-        <xs:attribute name="test" type="MetaschemaPathType" use="required">
-          <xs:annotation>
-            <xs:documentation>A test that is expected to pass in this context. Presently, data typing
-              is not directly supported except by explicit use of data type casting functions, e.g.
-              xs:double() and xs:date().</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:complexType name="ScopedExpectConstraintType">
-    <xs:complexContent>
-      <xs:extension base="ExpectConstraintType">
-        <xs:attribute name="target" type="MetaschemaPathType" use="required">
-          <xs:annotation>
-            <xs:documentation>Specifies the target of the constraint as a Metaschema expression. If the value is "." and the containing Metaschema object is a field or flag, the constraint applies to the value of the field or flag. Otherwise, the scope value "." is not allowed to be used.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:group name="CommonModelConstraintsGroup">
-    <xs:choice>
-      <xs:element name="allowed-values" type="ScopedAllowedValuesType">
-        <xs:annotation>
-          <xs:documentation>Constrains the allowed values for the flag or field referenced by the scope attribute.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="matches" type="ScopedMatchesConstraintType">
-        <xs:annotation>
-          <xs:documentation>Constrains the allowed values based on the provided regex pattern or checks that the value is conformant to the specified data type.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="index-has-key" type="ScopedIndexHasKeyConstraintType">
-        <xs:annotation>
-          <xs:documentation>Checks that the specified <code>key-field</code> values match a key in the index with the specified <code>name</code>.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="expect" type="ScopedExpectConstraintType">
-        <xs:annotation>
-          <xs:documentation>Checks that the specified test returns true in this evaluation context.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-    </xs:choice>
-  </xs:group>
-
-  <xs:complexType name="HasCardinalityConstraintType">
-    <xs:complexContent>
-      <xs:extension base="ConstraintType">
-        <xs:sequence>
-          <xs:group ref="ConstraintContentsGroup"/>
-        </xs:sequence>
-        <xs:attribute name="target" type="MetaschemaPathType" use="required">
-          <xs:annotation>
-            <xs:documentation>Specifies the target of the constraint as a Metapath expression. If the
-              value is "." and the containing Metaschema object is a field, the constraint applies
-              to the field's value. Otherwise, the scope value "." is not allowed to be
-              used.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="min-occurs" type="NonNegativeIntegerDatatype">
-          <xs:annotation>
-            <xs:documentation>Minimum occurrence of assemblies or fields within the set of objects
-              identified by the <code>target</code>. This value cannot be less than the
-              corresponding value defined on the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="max-occurs" type="NonNegativeIntegerDatatype">
-          <xs:annotation>
-            <xs:documentation>Maximum occurrence of assemblies or fields within the set of objects
-              identified by the <code>target</code>. This value must be less than the corresponding
-              value defined on the target.</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
-      </xs:extension>
-    </xs:complexContent>
-  </xs:complexType>
-
-  <xs:group name="AssemblyConstraintsGroup">
-    <xs:choice>
-      <xs:element name="index" type="ScopedIndexConstraintType">
-        <xs:annotation>
-          <xs:documentation>Defines a new named index. Each entry in the index will have a unique key, based on the <code>key-field</code> elements, and an associated object value, based on the <code>target</code> selection..</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="is-unique" type="ScopedKeyConstraintType">
-        <xs:annotation>
-          <xs:documentation>Checks that the specified set of <code>target</code> entries have a key, based on the <code>key-field</code> entries that is unique. The <code>name</code> identifies the name of the uniqueness constraint, which can be used for error reporting, etc.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="has-cardinality" type="HasCardinalityConstraintType">
-        <xs:annotation>
-          <xs:documentation>Checks that the specified set of <code>target</code> entries match the provided cardinality.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-    </xs:choice>
-  </xs:group>
-
-  <xs:complexType name="DefineFieldConstraintsType">
-    <xs:sequence>
-      <xs:choice minOccurs="1" maxOccurs="unbounded">
-        <xs:group ref="CommonModelConstraintsGroup"/>
-      </xs:choice>
-      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
-    </xs:sequence>
-  </xs:complexType>
-
-  <xs:complexType name="DefineAssemblyConstraintsType">
-    <xs:sequence>
-      <xs:choice minOccurs="1" maxOccurs="unbounded">
-        <xs:group ref="CommonModelConstraintsGroup"/>
-        <xs:group ref="AssemblyConstraintsGroup"/>
-      </xs:choice>
-      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
-    </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="ChoiceType">
@@ -1078,7 +564,7 @@
 
   <xs:complexType name="AnyType">
     <xs:annotation>
-      <xs:documentation>Within a model, a foreign element may be permitted here..</xs:documentation>
+      <xs:documentation>Within a model, a foreign element may be permitted here.</xs:documentation>
     </xs:annotation>
   </xs:complexType>
 
@@ -1086,9 +572,8 @@
     <xs:sequence>
       <xs:element name="description" type="MarkupLineDatatype" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>A short description of the example that provides basic documentation about the example's purpose.</xs:documentation>
+          <xs:documentation>A short description providing basic documentation about the example's purpose.</xs:documentation>
         </xs:annotation>
-
       </xs:element>
       <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
       <xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -1101,7 +586,7 @@
 
   <xs:complexType name="JsonKeyType">
     <xs:annotation>
-      <xs:documentation>In the XML, produces an attribute with the given name, whose value is used as a key value (aka object property name) in the JSON, enabling objects to be 'lifted' out of arrays when such values are distinct. Implies that siblings will never share values. Overloading with datatype 'ID' and naming the key 'id' is legitimate and useful. Even without ID validation, uniqueness of these values among siblings is validable.</xs:documentation>
+      <xs:documentation>In the XML, produces an attribute with the given name, whose value is used as a key value (aka object property name) in the JSON, enabling objects to be 'lifted' out of arrays when such values are distinct. Implies that siblings will never share values.</xs:documentation>
     </xs:annotation>
     <xs:attribute name="flag-ref" type="ModelNameType"/>
     <!-- do not have to flag if required; it always will be <xs:attribute name="required" type="xs:NCName"/>-->
@@ -1234,4 +719,491 @@
       </xs:enumeration>
     </xs:restriction>
   </xs:simpleType>
+
+  <!-- ************************** -->
+  <!-- * Metaschema Constraints * -->
+  <!-- ************************** -->
+  <xs:simpleType name="MetaschemaPathType">
+    <xs:restriction base="StringDatatype"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="ConstraintType" abstract="true">
+    <xs:sequence>
+      <xs:group ref="DefinitionMetadataGroup"/>
+    </xs:sequence>
+    <xs:attribute name="id" type="TokenDatatype" use="optional"/>
+    <xs:attribute name="level" type="ConstraintLevelType" default="ERROR"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ConstraintLevelType">
+    <xs:restriction base="TokenDatatype">
+      <xs:enumeration value="CRITICAL">
+        <xs:annotation>
+          <xs:documentation>A violation of the constraint represents a serious fault in the content
+            that will prevent typical use of the content.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ERROR">
+        <xs:annotation>
+          <xs:documentation>A violation of the constraint represents a fault in the content. This
+            may include issues around compatibility, integrity, consistency, etc.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="WARNING">
+        <xs:annotation>
+          <xs:documentation>A violation of the constraint represents a potential issue
+            with the content.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="INFORMATIONAL">
+        <xs:annotation>
+          <xs:documentation>A violation of the constraint represents a point of interest.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:group name="ConstraintContentsGroup">
+    <xs:sequence>
+      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
+    </xs:sequence>
+  </xs:group>
+  
+  <xs:complexType name="AllowedValuesType">
+    <xs:annotation>
+      <xs:documentation>Indicates an enumeration of a set values to be recognized for a flag or field.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="ConstraintType">
+        <xs:sequence>
+          <xs:element name="enum" type="AllowedValueType" minOccurs="1" maxOccurs="unbounded"/>
+          <xs:group ref="ConstraintContentsGroup"/>
+        </xs:sequence>
+        <xs:attribute name="allow-other" type="YesNoType" default="no">
+          <xs:annotation>
+            <xs:documentation>The given enumerated value or values are inclusive of other values ('yes') or not ('no', the default)</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="extensible" type="ExtensibleEnumType" default="external">
+          <xs:annotation>
+            <xs:documentation>Determines if the given enumerated values may be extended by other allowed value constraints.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:simpleType name="ExtensibleEnumType">
+    <xs:restriction base="TokenDatatype">
+      <xs:enumeration value="model">
+        <xs:annotation>
+          <xs:documentation>Can be extended by constraints within the same module.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="external">
+        <xs:annotation>
+          <xs:documentation>Can be extended by external constraints.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="none">
+        <xs:annotation>
+          <xs:documentation>Cannot be extended.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="AllowedValueType">
+    <xs:annotation>
+      <xs:documentation>An enumerated value for a flag or field. The value is indicated by the 'value' attribute while the element contents describe the intended semantics for documentation.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="MarkupLineDatatype">
+        <xs:attribute name="value" use="required" type="StringDatatype">
+          <xs:annotation>
+            <xs:documentation>A value recognized for a flag or field.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attributeGroup ref="DeprecationAttributeGroup"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:simpleType name="RegexType">
+    <xs:annotation>
+      <xs:documentation>A regular expression subset that conforms to both https://www.w3.org/TR/xmlschema11-2/#regexes and https://www.ecma-international.org/ecma-262/11.0/index.html#sec-patterns.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="StringDatatype"/>
+  </xs:simpleType>
+
+  <xs:complexType name="MatchesConstraintType">
+    <xs:complexContent>
+      <xs:extension base="ConstraintType">
+        <xs:sequence>
+          <xs:group ref="ConstraintContentsGroup"/>
+        </xs:sequence>
+        <!-- TODO: need a rule to enforce that either a regex or a datatype is used; or make these element children and use a choice -->
+        <xs:attribute name="regex" type="RegexType"/>
+        <xs:attribute name="datatype" type="SimpleDatatypesType">
+          <xs:annotation>
+            <xs:documentation>Specifies the datatype for which the value identified by the scope
+              attribute must conform to.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="TargetedMatchesConstraintType">
+    <xs:complexContent>
+      <xs:extension base="MatchesConstraintType">
+        <xs:attribute name="target" type="MetaschemaPathType" use="required">
+          <xs:annotation>
+            <xs:documentation>Specifies the target of the constraint as a Metaschema Metapath. If the value is "." and the containing Metaschema object is a field, the constraint applies to the field's value. Otherwise, the scope value "." is not allowed to be used.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="TargetedAllowedValuesConstraintType">
+    <xs:complexContent>
+      <xs:extension base="AllowedValuesType">
+        <xs:attribute name="target" type="MetaschemaPathType" use="required">
+          <xs:annotation>
+            <xs:documentation>Specifies the target of the constraint as a Metaschema Metapath. If the value is "." and the containing Metaschema object is a field, the constraint applies to the field's value.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="IndexFieldType">
+    <xs:sequence>
+      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="target" type="MetaschemaPathType" use="required">
+      <xs:annotation>
+        <xs:documentation>Specifies the field or flag value that is used to generate the key for a given object that is a member of this index. If more than one key-field is provided, then the key is a composition of the specified key-field objects. The ordering of the key-field objects establish the relative order of the index's key. The field or flag values pointed to are a field or flag value, which can be an empty value if not provided. Note: Multiple empty values can result in key conflicts.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="KeyConstraintType">
+    <xs:annotation>
+      <xs:documentation>Defines an unique key constraint.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="ConstraintType">
+        <xs:sequence>
+          <xs:element name="key-field" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>Specifies a value, relative to the provided <code>target</code>,
+                that is to be used as part of the key. More than one key-field can be used to create
+                a composite key.</xs:documentation>
+            </xs:annotation>
+            <xs:complexType>
+              <xs:complexContent>
+                <xs:extension base="IndexFieldType">
+                  <xs:attribute name="pattern" type="RegexType">
+                    <xs:annotation>
+                      <xs:documentation>The first captured group in the regular expression is used
+                        as the key value for lookup. The regular expression must not match a
+                        zero-length string.</xs:documentation>
+                    </xs:annotation>
+                  </xs:attribute>
+                </xs:extension>
+              </xs:complexContent>
+            </xs:complexType>
+          </xs:element>
+          <xs:group ref="ConstraintContentsGroup"/>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="TargetedKeyConstraintType">
+    <xs:complexContent>
+      <xs:extension base="KeyConstraintType">
+        <xs:attribute name="target" type="MetaschemaPathType" use="required">
+          <xs:annotation>
+            <xs:documentation>Specifies a Metapath that can be evaluated to get the value objects to be included in the key constraint, or the object that contains a reference to an item in an index. If the value is ".", then the key is targeting the current Metaschema object.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="IndexHasKeyConstraintType">
+    <xs:annotation>
+      <xs:documentation>Defines an index, a check against an index, or a uniqueness constraint.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="KeyConstraintType">
+        <xs:attribute name="name" type="ModelNameType" use="required">
+          <xs:annotation>
+            <xs:documentation>Specifies the name of the index, a reference to an index, or the name of a uniqueness constraint.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="TargetedIndexHasKeyConstraintType">
+    <xs:annotation>
+      <xs:documentation>Defines an index, a check against an index, or a uniqueness constraint.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="IndexHasKeyConstraintType">
+        <xs:attribute name="target" type="MetaschemaPathType" use="required">
+          <xs:annotation>
+            <xs:documentation>Specifies a Metapath that can be evaluated to get the value objects to be included in the index constraint, or the object that contains a reference to an item in an index. If the value is ".", then the key is targeting the current Metaschema object.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="TargetedIndexConstraintType">
+    <xs:annotation>
+      <xs:documentation>Defines an index, a check against an index, or a uniqueness constraint.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="KeyConstraintType">
+        <xs:attribute name="target" type="MetaschemaPathType" use="required">
+          <xs:annotation>
+            <xs:documentation>Specifies the value objects to be included in the index constraint, or the object that contains a reference to an item in an index. If the value is ".", then the key is targeting the current Metaschema object.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="name" type="ModelNameType" use="required">
+          <xs:annotation>
+            <xs:documentation>Specifies the name of the index, a reference to an index, or the name of a uniqueness constraint.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="ExpectConstraintType">
+    <xs:complexContent>
+      <xs:extension base="ConstraintType">
+        <xs:sequence>
+          <xs:element name="message" type="StringDatatype" minOccurs="0"/>
+          <xs:group ref="ConstraintContentsGroup"/>
+        </xs:sequence>
+        <xs:attribute name="test" type="MetaschemaPathType" use="required">
+          <xs:annotation>
+            <xs:documentation>A Metapath test that is expected to pass in this context.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="TargetedExpectConstraintType">
+    <xs:complexContent>
+      <xs:extension base="ExpectConstraintType">
+        <xs:attribute name="target" type="MetaschemaPathType" use="required">
+          <xs:annotation>
+            <xs:documentation>Specifies the target of the constraint as a Metaschema Metapath. If the value is "." and the containing Metaschema object is a field or flag, the constraint applies to the value of the field or flag. Otherwise, the scope value "." is not allowed to be used.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="TargetedHasCardinalityConstraintType">
+    <xs:complexContent>
+      <xs:extension base="ConstraintType">
+        <xs:sequence>
+          <xs:group ref="ConstraintContentsGroup"/>
+        </xs:sequence>
+        <xs:attribute name="target" type="MetaschemaPathType" use="required">
+          <xs:annotation>
+            <xs:documentation>Specifies the target of the constraint as a Metaschema Metapath. If the
+              value is "." and the containing Metaschema object is a field, the constraint applies
+              to the field's value. Otherwise, the scope value "." is not allowed to be
+              used.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="min-occurs" type="NonNegativeIntegerDatatype">
+          <xs:annotation>
+            <xs:documentation>Minimum occurrence of assemblies or fields within the set of objects
+              identified by the <code>target</code>. This value cannot be less than the
+              corresponding value defined on the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-occurs" type="NonNegativeIntegerDatatype">
+          <xs:annotation>
+            <xs:documentation>Maximum occurrence of assemblies or fields within the set of objects
+              identified by the <code>target</code>. This value must be less than the corresponding
+              value defined on the target.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <xs:complexType name="DefineFlagConstraintsType">
+    <xs:sequence>
+      <xs:choice maxOccurs="unbounded">
+        <xs:element minOccurs="0" name="allowed-values" type="AllowedValuesType">
+          <xs:annotation>
+            <xs:documentation>Constrains the allowed values for the flag.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="matches" type="MatchesConstraintType">
+          <xs:annotation>
+            <xs:documentation>Constrains the allowed values based on the provided regex pattern.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="index-has-key" type="IndexHasKeyConstraintType">
+          <xs:annotation>
+            <xs:documentation>Checks that the specified <code>key-field</code> values match a key in the index with the specified <code>name</code>.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="expect" type="ExpectConstraintType">
+          <xs:annotation>
+            <xs:documentation>Checks that the specified test returns true in this evaluation context.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+      </xs:choice>
+      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:group name="TargetedCommonConstraintsGroup">
+    <xs:choice>
+      <xs:element name="allowed-values" type="TargetedAllowedValuesConstraintType">
+        <xs:annotation>
+          <xs:documentation>Constrains the allowed values for the flag or field referenced by the scope attribute.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="matches" type="TargetedMatchesConstraintType">
+        <xs:annotation>
+          <xs:documentation>Constrains the allowed values based on the provided regex pattern or checks that the value conforms to the specified datatype.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="index-has-key" type="TargetedIndexHasKeyConstraintType">
+        <xs:annotation>
+          <xs:documentation>Checks that the specified <code>key-field</code> values match a key in the index with the specified <code>name</code>.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="expect" type="TargetedExpectConstraintType">
+        <xs:annotation>
+          <xs:documentation>Checks that the specified test returns true in this evaluation context.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:choice>
+  </xs:group>
+
+  <xs:group name="AssemblyConstraintsGroup">
+    <xs:choice>
+      <xs:element name="index" type="TargetedIndexConstraintType">
+        <xs:annotation>
+          <xs:documentation>Defines a new named index. Each entry in the index will have a unique key, based on the <code>key-field</code> elements, and an associated object value, based on the <code>target</code> selection..</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="is-unique" type="TargetedKeyConstraintType">
+        <xs:annotation>
+          <xs:documentation>Checks that the specified set of <code>target</code> entries have a key, based on the <code>key-field</code> entries that is unique. The <code>name</code> identifies the name of the uniqueness constraint, which can be used for error reporting, etc.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="has-cardinality" type="TargetedHasCardinalityConstraintType">
+        <xs:annotation>
+          <xs:documentation>Checks that the specified set of <code>target</code> entries match the provided cardinality.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:choice>
+  </xs:group>
+
+  <xs:complexType name="DefineFieldConstraintsType">
+    <xs:sequence>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:group ref="TargetedCommonConstraintsGroup"/>
+      </xs:choice>
+      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="DefineAssemblyConstraintsType">
+    <xs:sequence>
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
+        <xs:group ref="TargetedCommonConstraintsGroup"/>
+        <xs:group ref="AssemblyConstraintsGroup"/>
+      </xs:choice>
+      <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- *********************************** -->
+  <!-- * Metaschema External Constraints * -->
+  <!-- *********************************** -->
+  <xs:element name="METASCHEMA-CONSTRAINTS">
+    <xs:annotation>
+      <xs:documentation>Root element of a Metaschema external constraints definition. Defines rules to be applied to an existing set of Metaschema models.</xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="name" type="StringDatatype">
+          <xs:annotation>
+            <xs:documentation>The name of this constraint set.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="version" type="VersionType">
+          <xs:annotation>
+            <xs:documentation>The version of this constraint set.</xs:documentation>
+          </xs:annotation>
+        </xs:element>
+        <xs:element name="import" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>To import a set of Metaschema constraints from an out-of-line resource, supporting composition of constraint sets.</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="href" type="URIReferenceDatatype" use="required">
+              <xs:annotation>
+                <xs:documentation>A relative or absolute URI for retrieving an out-of-line Metaschema definition.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="scope" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:choice maxOccurs="unbounded">
+              <xs:element name="assembly">
+                <xs:complexType>
+                  <xs:complexContent>
+                    <xs:extension base="DefineAssemblyConstraintsType">
+                      <xs:attribute name="target" type="MetaschemaPathType" use="required"/>
+                    </xs:extension>
+                  </xs:complexContent>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="field">
+                <xs:complexType>
+                  <xs:complexContent>
+                    <xs:extension base="DefineFieldConstraintsType">
+                      <xs:attribute name="target" type="MetaschemaPathType" use="required"/>
+                    </xs:extension>
+                  </xs:complexContent>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="flag">
+                <xs:complexType>
+                  <xs:complexContent>
+                    <xs:extension base="DefineFlagConstraintsType">
+                      <xs:attribute name="target" type="MetaschemaPathType" use="required"/>
+                    </xs:extension>
+                  </xs:complexContent>
+                </xs:complexType>
+              </xs:element>
+            </xs:choice>
+            <xs:attribute name="metaschema-namespace" type="URIDatatype" use="required"/>
+            <xs:attribute name="metaschema-short-name" type="ShortNameType" use="required"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="remarks" type="RemarksType" minOccurs="0"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 </xs:schema>

--- a/website/content/specification/syntax/constraints.md
+++ b/website/content/specification/syntax/constraints.md
@@ -24,6 +24,37 @@ During constraint evaluation, each `let` statement MUST be evaluated in encounte
 
 During evaluation, when a variable is bound for a `let` statement, the variables value MUST be set to the result of evaluating the `@expression` using the current node as the Metapath evaluation focus.
 
+For example:
+
+Given the following fragment of a Metaschema module.
+
+```xml
+<define-assembly name="sibling">
+  <define-flag name="name" required="yes"/>
+  <constraint>
+    <let var="parent" expression=".."/><!-- stores the parent of the current node -->
+    <let var="sibling-count" expression="count($parent/sibling)"/>
+    <expect target="." test="$sibling-count = 3"/>
+  </constraint>
+</define-assembly>
+```
+
+And the following document.
+
+```xml
+<parent name="p1">
+  <sibling name="a"/>
+  <sibling name="b"/>
+  <sibling name="c"/>
+</parent>
+<parent name="p2">
+  <sibling name="x"/>
+  <sibling name="Y"/>
+</parent1>
+```
+
+The expect constraint would pass for each `sibling` in the `parent` named "p1", and would fail for each `sibling` in the `parent` named "p2".
+
 ## Enumerated values
 
 Additionally, flags may be constrained to a set of known values listed in advance.

--- a/website/content/specification/syntax/constraints.md
+++ b/website/content/specification/syntax/constraints.md
@@ -12,6 +12,18 @@ TODO: P3: Address issue https://github.com/usnistgov/metaschema/issues/325
 
 ## Common Constraint Data
 
+## Let expressions
+
+Using the `let` element, a variable can be defined, which can be used in a Metapath expression in subsequent constraints.
+
+A `let` statement has a REQUIRED `@var` attribute, which defines the variable name.
+
+A `let` statement has a REQUIRED `@expression` attributes, which defines an Metapath expression, whose result is used to define the variable's value in the evaluation context.
+
+During constraint evaluation, each `let` statement MUST be evaluated in encounter order. If a previous variable is bound with the same name in the evaluation context, the new value MUST bound in a sub-context to avoid side effects. This sub-context MUST be made available to any constraints following the `let` statement declaration, and to any constraints defined on child nodes of the current context.
+
+During evaluation, when a variable is bound for a `let` statement, the variables value MUST be set to the result of evaluating the `@expression` using the current node as the Metapath evaluation focus.
+
 ## Enumerated values
 
 Additionally, flags may be constrained to a set of known values listed in advance.


### PR DESCRIPTION
# Committer Notes

Adding support for let expressions in constraints.

Also cleaned up the Metaschema XML schema, moving all constraint-related constructs to a section of the schema.


### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- ~~[ ] Have you written new tests for your core changes, as applicable?~~
- [x] Have you included examples of how to use your new feature(s)?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
