### PR TITLE
Document `expect` constraint

### DIFF
--- a/website/content/specification/syntax/constraints.md
+++ b/website/content/specification/syntax/constraints.md
@@ -169,15 +169,15 @@ The `expect` constraint is a type of Metaschema constraint that restricts field 
 
 The `@target` attribute of an `<expect>` constraint specifies the node(s) in a document instance whose value is restricted by the constraint.
 
-The `@test` attribute of an `<expect>` constraint specifies the logical condition to be evaluated against each value node resulting from evaluating the `@target`. This expression must evaluate to [a Metaschema boolean value](/specification/datatypes#boolean) `true` or `false`.
+The `@test` attribute of an `<expect>` constraint specifies the logical condition to be evaluated against each value node resulting from evaluating the `@target`. This expression MUST evaluate to [a Metaschema boolean value](/specification/datatypes#boolean) `true` or `false`.
 
-When the `@test` expression evaluates to `true` for a value node, then the value node is considered valid and passes the constraint.
+When the `@test` expression evaluates to `true` for a target value node, then the target value node MUST be considered valid and passing the constraint.
 
-When the `@test` expression evaluates to `false` for a value node, then the value node is considered not valid and fails the constraint.
+When the `@test` expression evaluates to `false` for a target value node, then the target value node MUST be considered not valid and failing the constraint.
 
-A constraint may have an optional [`@level`](#level) attribute and/or an optional child [`<message>`](#message) element to indicate severity and documentation explaining how the target nodes are invalid.
+A constraint may have an OPTIONAL [`@level`](#level) attribute and/or an OPTIONAL child [`<message>`](#message) element to indicate severity and documentation explaining how the target nodes are invalid.
 
-If defined, the `<message>` value MUST be a [Metaschema string value](/specification/datatypes#string). It may contain a Metapath expression templates that start with `{`, contain a Metapath expression, and end with `}`.  When evaluating a template Metapath expression, the context of the Metapath [evaluation focus](#constraint-processing) will be the failing value node.
+If defined, the `<message>` value MUST be a [Metaschema string value](/specification/datatypes#string). It MAY contain a Metapath expression templates that starts with `{`, contains a Metapath expression, and ends with `}`.  When evaluating a template Metapath expression, the context of the Metapath [evaluation focus](#constraint-processing) MUST be the failing value node.
 
 ## Enumerated values
 

--- a/website/content/specification/syntax/constraints.md
+++ b/website/content/specification/syntax/constraints.md
@@ -163,6 +163,21 @@ And the following document.
 
 The expect constraint would pass for each `sibling` in the `parent` named "p1", and would fail for each `sibling` in the `parent` named "p2".
 
+## `expect` constraints
+
+The `expect` constraint is a type of Metaschema constraint that restricts field or flag value(s) based on the evaluation of a test Metapath expression.
+
+The `@target` attribute of an `<expect>` constraint specifies the node(s) in a document instance whose value is restricted by the constraint.
+
+The `@test` attribute of an `<expect>` constraint specifies the logical condition to be evaluated against each value node resulting from evaluating the `@target`. This expression must evaluate to [a Metaschema boolean value](/specification/datatypes#boolean) `true` or `false`.
+
+When the `@test` expression evaluates to `true` for a value node, then the value node is considered valid and passes the constraint.
+
+When the `@test` expression evaluates to `false` for a value node, then the value node is considered not valid and fails the constraint.
+
+A constraint may have an optional [`@level`](#level) attribute and/or an optional child [`<message>`](#message) element to indicate severity and documentation explaining how the target nodes are invalid.
+
+If defined, the `<message>` value MUST be a [Metaschema string value](/specification/datatypes#string). It may contain a Metapath expression templates that start with `{`, contain a Metapath expression, and end with `}`.  When evaluating a template Metapath expression, the context of the Metapath [evaluation focus](#constraint-processing) will be the failing value node.
 
 ## Enumerated values
 


### PR DESCRIPTION
# Committer Notes

This PR adds documentation for `expect` constraints. Closes #489.

**NOTE:** This PR is based on my fork branch associated with PR #413 with the presumption, based on previous conversation, that the 413 will be merged into develop before this PR and others in the 485. Once that is merged, I will rebase on the updated upstream develop branch.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
- ~Have you written new tests for your core changes, as applicable?~ N/A this is a specification update for existing functionality, adding or changing test suite will be in follow-on issues and PRs
- ~Have you included examples of how to use your new feature(s)?~ N/A Per request and feedback in Gitter and community meetings, examples will be added in tutorials and elsewhere after the specification is complete.
