### PR TITLE
Document `index` and `index-has-key` constraint

### DIFF
--- a/website/content/specification/syntax/constraints.md
+++ b/website/content/specification/syntax/constraints.md
@@ -18,7 +18,7 @@ The following constraint types are allowed for `<define-flag>` definitions.
 
 - [`<allowed-values>`](#enumerated-values)
 - `<matches>`
-- `<index-has-key>`
+- [`<index-has-key>`](#index-has-key-constraints)
 - `<expect>`
 
 For each of these constraint types, use of the `@target` attribute is prohibited. This is because a flag constraint may only target the flag, since a flag has no child nodes.
@@ -29,7 +29,7 @@ The following constraint types are allowed for `<define-field>` definitions.
 
 - [`<allowed-values>`](#enumerated-values)
 - `<matches>`
-- `<index-has-key>`
+- [`<index-has-key>`](#index-has-key-constraints)
 - `<expect>`
 
 ## `<define-assembly>` constraints
@@ -38,9 +38,9 @@ The following constraint types are allowed for `<define-assembly>` definitions.
 
 - [`<allowed-values>`](#enumerated-values)
 - `<matches>`
-- `<index-has-key>`
+- [`<index-has-key>`](#index-has-key-constraints)
 - `<expect>`
-- `<index>`
+- [`<index>`](#index-constraints)
 - `<is-unique>`
 - `<has-cardinality>`
 

--- a/website/content/specification/syntax/constraints.md
+++ b/website/content/specification/syntax/constraints.md
@@ -187,11 +187,11 @@ The `@name` attribute of an `<index>` constraint specifies the identity of the i
 
 The `@target` attribute of an `<index>` constraint defines the node(s) in a document instance to index. The index MUST define a [`@target`](#target) with a Metapath expression. The processor MUST index only The document instance node(s) resulting from its evaluation.
 
-The `<key-field>` child element of an `<index>` constraint defines the attribute or element value that is the key for each entry in the index. The `<key-field>` element MUST define a [`@target`](#target) attribute with a Metapath expression evaluated relative to [the evaluation focus](#constraint-processing) of each entry of the matches of the constraint's `@target`.
+The `<key-field/>` child element of an `<index>` constraint defines the attribute or element value that is the key for each entry in the index. The `<key-field/>` element MUST define a [`@target`](#target) attribute with a Metapath expression evaluated relative to [the evaluation focus](#constraint-processing) of each entry of the matches of the constraint's `@target`.
 
-An `index` constraint MAY define more than one `<key-field>` child element. The composite key for each entry in the index is the combination of values for the `@target` of every `<key-field/>`. The composite values of the key are the discriminator for the uniqueness of the index entry.
+An `index` constraint MAY define more than one `<key-field/>` child element. The composite key for each entry in the index is the combination of values for the `@target` of every `<key-field/>`. The composite values of the key are the discriminator for the uniqueness of the index entry.
 
-An `index` constraint requires the each member entry be unique based upon this composite key.
+An `index` constraint requires that each member entry be unique based upon this composite key.
 
 If the evaluation of the Metapath `@target` of the `<key-field/>` does not result in a value, its value for that key in the index is null.
 

--- a/website/content/specification/syntax/constraints.md
+++ b/website/content/specification/syntax/constraints.md
@@ -179,6 +179,30 @@ A constraint may have an OPTIONAL [`@level`](#level) attribute and/or an OPTIONA
 
 If defined, the `<message>` value MUST be a [Metaschema string value](/specification/datatypes#string). It MAY contain a Metapath expression templates that starts with `{`, contains a Metapath expression, and ends with `}`.  When evaluating a template Metapath expression, the context of the Metapath [evaluation focus](#constraint-processing) MUST be the failing value node.
 
+## `index` constraints
+
+The `index` constraint is a type of Metaschema constraint that defines an index of document instance nodes addressable by key.
+
+The `@name` attribute of an `<index>` constraint specifies the identity of the index. The constraint MUST define the name.
+
+The `@target` attribute of an `<index>` constraint defines the node(s) in a document instance to index. The index MUST define a [`@target`](#target) with a Metapath expression. The processor MUST index only The document instance node(s) resulting from its evaluation.
+
+The `<key-field>` child element of an `<index>` constraint defines the attribute or element value that is the key for each entry in the index. The `<key-field>` element MUST define a [`@target`](#target) attribute with a Metapath expression evaluated relative to [the evaluation focus](#constraint-processing) of each entry of the matches of the constraint's `@target`.
+
+An `index` constraint MAY define more than one `<key-field>` child element. The composite key for each entry in the index is the combination of values for the `@target` of every `<key-field/>`. The composite values of the key are the discriminator for the uniqueness of the index entry.
+
+An `index` constraint requires the each member entry be unique based upon this composite key.
+
+If the evaluation of the Metapath `@target` of the `<key-field/>` does not result in a value, its value for that key in the index is null.
+
+## `index-has-key` constraints
+
+The `index-has-key` constraint is a type of Metaschema constraint that cross-references values an existing `index` constraint` with a separate `@target` and `<key-field/>`.
+
+The `@name` attribute of an `<index>` constraint MUST specify the name of a previously defined `index` constraint.
+
+The `index-has-key` constraint has the same attributes and child elements as a [`index`](#index-constraints) constraint.
+
 ## Enumerated values
 
 The `allowed-values` constraint is a type of Metaschema constraint that restricts field or flag value(s) based on an enumerated set of permitted values.

--- a/website/content/specification/syntax/constraints.md
+++ b/website/content/specification/syntax/constraints.md
@@ -183,13 +183,13 @@ If defined, the `<message>` value MUST be a [Metaschema string value](/specifica
 
 The `index` constraint is a type of Metaschema constraint that defines an index of document instance nodes addressable by key.
 
-The `@name` attribute of an `<index>` constraint specifies the identity of the index. The constraint MUST define the name.
+The `@name` flag of an `<index>` constraint specifies the identity of the index. The constraint MUST define the name.
 
-The `@target` attribute of an `<index>` constraint defines the node(s) in a document instance to index. The index MUST define a [`@target`](#target) with a Metapath expression. The processor MUST index only The document instance node(s) resulting from its evaluation.
+The `@target` flag of an `<index>` constraint defines the node(s) in a document instance to index. The index MUST define a [`@target`](#target) with a Metapath expression. The processor MUST index only The document instance node(s) resulting from its evaluation.
 
-The `<key-field/>` child element of an `<index>` constraint defines the attribute or element value that is the key for each entry in the index. The `<key-field/>` element MUST define a [`@target`](#target) attribute with a Metapath expression evaluated relative to [the evaluation focus](#constraint-processing) of each entry of the matches of the constraint's `@target`.
+The `<key-field>` assembly of an `<index>` constraint defines the flag or field value that is the key for each entry in the index. The `<key-field>` field MUST define a [`@target`](#target) flag with a Metapath expression evaluated relative to [the evaluation focus](#constraint-processing) of each entry of the matches of the constraint's `@target`.
 
-An `index` constraint MAY define more than one `<key-field/>` child element. The composite key for each entry in the index is the combination of values for the `@target` of every `<key-field/>`. The composite values of the key are the discriminator for the uniqueness of the index entry.
+An `index` constraint MAY define more than one `<key-field>` assembly. The composite key for each entry in the index is the combination of values for the `@target` of every `<key-field/>`. The composite values of the key are the discriminator for the uniqueness of the index entry.
 
 An `index` constraint requires that each member entry be unique based upon this composite key.
 
@@ -199,9 +199,9 @@ If the evaluation of the Metapath `@target` of the `<key-field/>` does not resul
 
 The `index-has-key` constraint is a type of Metaschema constraint that cross-references values an existing `index` constraint` with a separate `@target` and `<key-field/>`.
 
-The `@name` attribute of an `<index>` constraint MUST specify the name of a previously defined `index` constraint.
+The `@name` flag of an `<index>` constraint MUST specify the name of a previously defined `index` constraint.
 
-The `index-has-key` constraint has the same attributes and child elements as a [`index`](#index-constraints) constraint.
+The `index-has-key` constraint has the same flags and assemblies as a [`index`](#index-constraints) constraint.
 
 ## Enumerated values
 


### PR DESCRIPTION
# Committer Notes

This PR adds documentation for `index` and `index-has-key` constraints. Closes #490.

**NOTE:** This PR is based on my fork branch associated with PR 493, queued up for after #413 is  merged into develop before this PR and others in the 485. Once 413/493 is merged, I will rebase on the updated upstream develop branch.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
- ~Have you written new tests for your core changes, as applicable?~ N/A this is a specification update for existing functionality, adding or changing test suite will be in follow-on issues and PRs
- ~Have you included examples of how to use your new feature(s)?~ N/A Per request and feedback in Gitter and community meetings, examples will be added in tutorials and elsewhere after the specification is complete.
