### PR TITLE
Change tutorial titles for better sidenav order

### DIFF
--- a/website/content/tutorials/1-getting-started/_index.md
+++ b/website/content/tutorials/1-getting-started/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started with Metaschema"
+title: "Tutorial #1: Getting Started with Metaschema"
 description: ""
 ---
 

--- a/website/content/tutorials/2-constraints/_index.md
+++ b/website/content/tutorials/2-constraints/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Using Constraints"
+title: "Tutorial #2: Using Constraints"
 description: ""
 ---
 

--- a/website/content/tutorials/3-constraints-expect/_index.md
+++ b/website/content/tutorials/3-constraints-expect/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Complex Constraints: expect"
+title: "Tutorial #3: Complex Constraints: expect"
 description: ""
 ---
 

--- a/website/content/tutorials/4-constraints-matches/_index.md
+++ b/website/content/tutorials/4-constraints-matches/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Complex Constraints: matches"
+title: "Tutorial #4: Complex Constraints: matches"
 description: ""
 ---
 

--- a/website/content/tutorials/_index.md
+++ b/website/content/tutorials/_index.md
@@ -7,8 +7,11 @@ menu:
     weight: 10
 ---
 
-# Tutorials
+# Learning Metaschema by example
 
 The following tutorials provide walk-throughs for developers to understand Metaschema, its use cases, and how to use or develop news to exercise them.
 
-- [Getting Started with Metaschema](1-getting-started/): Introduces the basics of Metaschema-based modeling using a "computer" model as an example.
+- [Tutorial #1:: Getting Started with Metaschema](1-getting-started/): Introduces the basics of Metaschema-based modeling using a "computer" model as an example.
+- [Tutorial #2: Using Constraints](2-constraints/): Introduces Metaschema constraints and how to use them for more precise control for values in model-based document instances.
+- [Tutorial #3: Complex Constraints: expect](3-constraints-expect/): Introduces advanced usage of Metaschema constraints, specifically `expect` and its common use cases.
+- [Tutorial #4: Complex Constraints: matches](4-constraints-matches/): Introduces advanced usage of Metaschema constraints, specifically `matches` and common its use cases.


### PR DESCRIPTION
# Committer Notes

While reviewing 1.0.0-milestone1 code and site updates before release, I noticed that the [hugo theme](https://github.com/usnistgov/hugo-uswds/) obviously drives side navigation based on each page title, not the the partial or full URL. 🤦 So I am explicitly adding them in the titles so the tutorials go in progression from easier to harder.

I have provided a screenshot from local dev environment below.

![image](https://github.com/usnistgov/metaschema/assets/94922603/fe5e7d41-5dcd-47ee-b189-fc929434bf93)

![image](https://github.com/usnistgov/metaschema/assets/94922603/d69c78f2-ab27-43c5-b07f-24e5da7eab26)


### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
- ~Have you written new tests for your core changes, as applicable?~ No, that would be applicable given discussion of upstream theme and changes to its functionality for sidenav sort, if applicable, not in the website content in this repo.
- ~Have you included examples of how to use your new feature(s)?~ N/A for website content changes.