### PR TITLE
Metaschema Module External Constraints

### DIFF
--- a/schema/metaschema/metaschema-module-constraints.xml
+++ b/schema/metaschema/metaschema-module-constraints.xml
@@ -3,6 +3,44 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../xml/metaschema-meta-constraints.xsd">
     <context>
-        <metapath target="/metaschema-meta-constraints"/>
+        <metapath target="/METASCHEMA"/>
+        <constraints>
+            <let var="all-imports" expression="recurse-depth(.,'doc(resolve-uri(import/@href))/METASCHEMA'"/>
+            <index id="metaschema-short-name-unique" target="(.|$all-imports)" name="metaschema-metadata-short-name-index">
+                <formal-name>Unique Module Short Names</formal-name>
+                <description>Ensures that the current and all imported modules have a unique short name.</description>
+                <key-field target="@short-name"/>
+            </index>
+        </constraints>
+        <context>
+            <metapath target=".[not(@abstract) or @abstract='yes']"/>
+            <constraints>
+                <expect id="metaschema-top-level-version-required" target="." test="@version">
+                    <formal-name>Require Version for Top-Level Modules</formal-name>
+                    <description>A top-level module, a module that is not marked as @abstract='yes', must have a version specified.</description>
+                    <message>Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have a version.</message>
+                </expect>
+                <expect id="metaschema-top-level-root-required" target="." test="define-assembly/root-name">
+                    <formal-name>Require Root Assembly for Top-Level Modules</formal-name>
+                    <description>A top-level module, a module that is not marked as @abstract='yes', must have at least one assembly with a root-name.</description>
+                    <message>Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have at least one assembly with a root-name.</message>
+                </expect>
+            </constraints>
+        </context>
+        <context>
+            <metapath target="import"/>
+            <constraints>
+                <expect id="metaschema-import-href-available" target="." test="document-available(resolve-uri(import/@href))">
+                    <formal-name>Import is Resolvable</formal-name>
+                    <description>Ensure each import has a resolvable @href.</description>
+                    <message>Unable to access a Metaschema module at '{{ resolve-uri(@href) }}'.</message>
+                </expect>
+                <expect id="metaschema-import-href-is-module" target="." test="exists(doc(resolve-uri(import/@href))/METASCHEMA)">
+                    <formal-name>Import is Resolvable</formal-name>
+                    <description>Ensure each import is a Metaschema module.</description>
+                    <message>Unable the resource at '{{ resolve-uri(@href) }}' is not a Metaschema module.</message>
+                </expect>
+            </constraints>
+        </context>
     </context>
 </metaschema-meta-constraints>


### PR DESCRIPTION


# Committer Notes

Some work towards representing the XSLT-based [metaschema-composition-check.sch](https://github.com/usnistgov/metaschema-xslt/blob/develop/src/validate/metaschema-composition-check.sch) as Metaschema external module constraints.

Work towards addressing #556.

### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
