### PR TITLE
Patch decimal type

### DIFF
--- a/schema/json/metaschema-datatypes.json
+++ b/schema/json/metaschema-datatypes.json
@@ -43,8 +43,7 @@
     },
     "DecimalDatatype": {
       "description": "A real number expressed using a whole and optional fractional part separated by a period.",
-      "type": "number",
-      "pattern": "^(\\+|-)?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)$"
+      "type": "number"
     },
     "EmailAddressDatatype": {
       "description": "An email address string formatted according to RFC 6531.",


### PR DESCRIPTION
# Committer Notes

This is a small fix to silence a warning i discovered when compiling the validator for a default JSON in metaschema using metaschema XSLT. a number type cannot have a pattern keyword, because pattern keyword is only for strings.
it is either, a string with a pattern or a number. This pull request assumes that the "number" is the desired type for this Decimal type.


### All Submissions:

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [ ] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
