### PR TITLE
Feature/module and meta constraints namespace prefixes

### DIFF
--- a/schema/metaschema/metaschema-module-constraints.xml
+++ b/schema/metaschema/metaschema-module-constraints.xml
@@ -5,7 +5,7 @@
     <context>
         <metapath target="/METASCHEMA"/>
         <constraints>
-            <let var="all-imports" expression="recurse-depth(.,'doc(resolve-uri(import/@href))/METASCHEMA'"/>
+            <let var="all-imports" expression="recurse-depth(.,'doc(resolve-uri(import/@href))/METASCHEMA')"/>
             <index id="metaschema-short-name-unique" target="(.|$all-imports)" name="metaschema-metadata-short-name-index">
                 <formal-name>Unique Module Short Names</formal-name>
                 <description>Ensures that the current and all imported modules have a unique short name.</description>
@@ -35,7 +35,7 @@
                     <description>Ensure each import has a resolvable @href.</description>
                     <message>Unable to access a Metaschema module at '{{ resolve-uri(@href) }}'.</message>
                 </expect>
-                <expect id="metaschema-import-href-is-module" target="." test="exists(doc(resolve-uri(import/@href))/METASCHEMA)">
+                <expect id="metaschema-import-href-is-module" target="." test="doc(resolve-uri(import/@href))/METASCHEMA ! exists(.)">
                     <formal-name>Import is Resolvable</formal-name>
                     <description>Ensure each import is a Metaschema module.</description>
                     <message>Unable the resource at '{{ resolve-uri(@href) }}' is not a Metaschema module.</message>

--- a/schema/metaschema/metaschema-module-constraints.xml
+++ b/schema/metaschema/metaschema-module-constraints.xml
@@ -5,42 +5,64 @@
     <context>
         <metapath target="/METASCHEMA"/>
         <constraints>
-            <let var="all-imports" expression="recurse-depth(.,'doc(resolve-uri(import/@href))/METASCHEMA')"/>
-            <index id="metaschema-short-name-unique" target="(.|$all-imports)" name="metaschema-metadata-short-name-index">
-                <formal-name>Unique Module Short Names</formal-name>
+            <let var="all-imports" expression="recurse-depth('doc(resolve-uri(import/@href))/METASCHEMA')"/>
+            <index id="module-short-name-unique" target="(.|$all-imports)" name="metaschema-metadata-short-name-index">
+                <formal-name>Index Module Short Names</formal-name>
                 <description>Ensures that the current and all imported modules have a unique short name.</description>
                 <key-field target="@short-name"/>
             </index>
+            <expect id="module-top-level-version-required" target=".[not(@abstract) or @abstract='yes']" test="@version">
+                <formal-name>Require Version for Top-Level Modules</formal-name>
+                <description>A top-level module, a module that is not marked as @abstract='yes', must have a version specified.</description>
+                <message>Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have a version.</message>
+            </expect>
+            <expect id="module-top-level-root-required" target=".[not(@abstract) or @abstract='yes']" test="define-assembly/root-name">
+                <formal-name>Require Root Assembly for Top-Level Modules</formal-name>
+                <description>A top-level module, a module that is not marked as @abstract='yes', must have at least one assembly with a root-name.</description>
+                <message>Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have at least one assembly with a root-name.</message>
+            </expect>
+            <is-unique id="module-namespace-unique-entry" target="namespace">
+                <formal-name>Require Unique Namespace Entries</formal-name>
+                <description>Ensures that all declared namespace entries are unique.</description>
+                <key-field target="@prefix"/>
+                <key-field target="@uri"/>
+            </is-unique>
+            <is-unique id="module-namespace-unique-prefix" target="namespace">
+                <formal-name>Require Unique Namespace Entry Prefixes</formal-name>
+                <description>Ensures that all declared namespace entries have a unique prefix.</description>
+                <key-field target="@prefix"/>
+            </is-unique>
         </constraints>
-        <context>
-            <metapath target=".[not(@abstract) or @abstract='yes']"/>
-            <constraints>
-                <expect id="metaschema-top-level-version-required" target="." test="@version">
-                    <formal-name>Require Version for Top-Level Modules</formal-name>
-                    <description>A top-level module, a module that is not marked as @abstract='yes', must have a version specified.</description>
-                    <message>Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have a version.</message>
-                </expect>
-                <expect id="metaschema-top-level-root-required" target="." test="define-assembly/root-name">
-                    <formal-name>Require Root Assembly for Top-Level Modules</formal-name>
-                    <description>A top-level module, a module that is not marked as @abstract='yes', must have at least one assembly with a root-name.</description>
-                    <message>Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have at least one assembly with a root-name.</message>
-                </expect>
-            </constraints>
-        </context>
         <context>
             <metapath target="import"/>
             <constraints>
-                <expect id="metaschema-import-href-available" target="." test="document-available(resolve-uri(import/@href))">
+                <expect id="module-import-href-available" target="." test="document-available(resolve-uri(import/@href))">
                     <formal-name>Import is Resolvable</formal-name>
                     <description>Ensure each import has a resolvable @href.</description>
                     <message>Unable to access a Metaschema module at '{{ resolve-uri(@href) }}'.</message>
                 </expect>
-                <expect id="metaschema-import-href-is-module" target="." test="doc(resolve-uri(import/@href))/METASCHEMA ! exists(.)">
+                <expect id="module-import-href-is-module" target="." test="doc(resolve-uri(import/@href))/METASCHEMA ! exists(.)">
                     <formal-name>Import is Resolvable</formal-name>
                     <description>Ensure each import is a Metaschema module.</description>
                     <message>Unable the resource at '{{ resolve-uri(@href) }}' is not a Metaschema module.</message>
                 </expect>
             </constraints>
         </context>
+    </context>
+    <context>
+        <metapath target="/metaschema-meta-constraints"/>
+        <constraints>
+            <is-unique id="meta-constraints-namespace-unique-entry" target="namespace">
+                <formal-name>Require Unique Namespace Entries</formal-name>
+                <description>Ensures that all declared namespace entries are unique.</description>
+                <key-field target="@prefix"/>
+                <key-field target="@uri"/>
+            </is-unique>
+            <is-unique id="meta-constraints-namespace-unique-prefix" target="namespace">
+                <formal-name>Require Unique Namespace Entry Prefixes</formal-name>
+                <description>Ensures that all declared namespace entries have a unique prefix.</description>
+                <key-field target="@prefix"/>
+            </is-unique>
+        </constraints>
     </context>
 </metaschema-meta-constraints>

--- a/schema/metaschema/metaschema-module-constraints.xml
+++ b/schema/metaschema/metaschema-module-constraints.xml
@@ -3,6 +3,44 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://csrc.nist.gov/ns/oscal/metaschema/1.0 ../xml/metaschema-meta-constraints.xsd">
     <context>
-        <metapath target="/metaschema-meta-constraints"/>
+        <metapath target="/METASCHEMA"/>
+        <constraints>
+            <let var="all-imports" expression="recurse-depth(.,'doc(resolve-uri(import/@href))/METASCHEMA'"/>
+            <index id="metaschema-short-name-unique" target="(.|$all-imports)" name="metaschema-metadata-short-name-index">
+                <formal-name>Unique Module Short Names</formal-name>
+                <description>Ensures that the current and all imported modules have a unique short name.</description>
+                <key-field target="@short-name"/>
+            </index>
+        </constraints>
+        <context>
+            <metapath target=".[not(@abstract) or @abstract='yes']"/>
+            <constraints>
+                <expect id="metaschema-top-level-version-required" target="." test="@version">
+                    <formal-name>Require Version for Top-Level Modules</formal-name>
+                    <description>A top-level module, a module that is not marked as @abstract='yes', must have a version specified.</description>
+                    <message>Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have a version.</message>
+                </expect>
+                <expect id="metaschema-top-level-root-required" target="." test="define-assembly/root-name">
+                    <formal-name>Require Root Assembly for Top-Level Modules</formal-name>
+                    <description>A top-level module, a module that is not marked as @abstract='yes', must have at least one assembly with a root-name.</description>
+                    <message>Unless marked as @abstract='yes', a Metaschema module (or an imported module) should have at least one assembly with a root-name.</message>
+                </expect>
+            </constraints>
+        </context>
+        <context>
+            <metapath target="import"/>
+            <constraints>
+                <expect id="metaschema-import-href-available" target="." test="document-available(resolve-uri(import/@href))">
+                    <formal-name>Import is Resolvable</formal-name>
+                    <description>Ensure each import has a resolvable @href.</description>
+                    <message>Unable to access a Metaschema module at '{{ resolve-uri(@href) }}'.</message>
+                </expect>
+                <expect id="metaschema-import-href-is-module" target="." test="exists(doc(resolve-uri(import/@href))/METASCHEMA)">
+                    <formal-name>Import is Resolvable</formal-name>
+                    <description>Ensure each import is a Metaschema module.</description>
+                    <message>Unable the resource at '{{ resolve-uri(@href) }}' is not a Metaschema module.</message>
+                </expect>
+            </constraints>
+        </context>
     </context>
 </metaschema-meta-constraints>

--- a/schema/metaschema/metaschema-module-metaschema.xml
+++ b/schema/metaschema/metaschema-module-metaschema.xml
@@ -793,7 +793,7 @@
         </constraint>
     </define-field>
     
-    <define-flag name="alt-name-index" as-type="nonNegativeInteger">
+    <define-flag name="alt-name-index" as-type="non-negative-integer">
         <formal-name>Numeric Index</formal-name>
         <description>Used for binary formats instead of the textual name.</description>
         <use-name>index</use-name>

--- a/schema/metaschema/metaschema-module-metaschema.xml
+++ b/schema/metaschema/metaschema-module-metaschema.xml
@@ -1313,7 +1313,8 @@
                 </model>
             </define-assembly>
             <assembly ref="metapath-context" min-occurs="1" max-occurs="unbounded">
-                <group-as name="metapath-contexts" in-json="ARRAY"/>
+		    	<use-name>context</use-name>
+                <group-as name="contexts" in-json="ARRAY"/>
             </assembly>
         </model>            
     </define-assembly>
@@ -1334,7 +1335,8 @@
                 <use-name>constraints</use-name>
             </assembly>
             <assembly ref="metapath-context" max-occurs="unbounded">
-                <group-as name="metapath-contexts" in-json="ARRAY"/>
+            	<use-name>context</use-name>
+                <group-as name="contexts" in-json="ARRAY"/>
             </assembly>
             <field ref="remarks"/>
         </model>

--- a/schema/metaschema/metaschema-module-metaschema.xml
+++ b/schema/metaschema/metaschema-module-metaschema.xml
@@ -52,6 +52,9 @@
                     <description>A relative or absolute URI for retrieving an out-of-line Metaschema definition.</description>
                 </define-flag>
             </define-assembly>
+            <assembly ref="metapath-namespace" max-occurs="unbounded">
+                <group-as name="namespace-bindings" />
+            </assembly>
             <choice-group max-occurs="unbounded">
                 <group-as name="definitions" in-json="ARRAY"/>
                 <discriminator>object-type</discriminator>
@@ -183,6 +186,21 @@
         </constraint>
     </define-assembly>
     
+    <define-assembly name="metapath-namespace">
+        <formal-name>Metapath Namespace Declaration</formal-name>
+        <description>Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.</description>
+        <use-name>namespace-binding</use-name>
+        <define-flag name="uri" as-type="uri" required="yes">
+            <formal-name>Metapath Namespace URI</formal-name>
+            <description>The namespace URI to bind to the prefix.</description>
+        </define-flag>
+        <define-flag name="prefix" as-type="token" required="yes">
+            <formal-name>Metapath Namespace Prefix</formal-name>
+            <description>The prefix that is bound to the namespace.</description>
+        </define-flag>
+    </define-assembly>
+
+
     <define-assembly name="inline-define-assembly">
         <formal-name>Inline Assembly Definition</formal-name>
         <use-name>define-assembly</use-name>
@@ -1238,6 +1256,11 @@
                     <description>A relative or absolute URI for retrieving an out-of-line Metaschema constraint definition.</description>
                 </define-flag>
             </define-assembly>
+            
+            <assembly ref="metapath-namespace" max-occurs="unbounded">
+                <group-as name="namespace-bindings" />
+            </assembly>
+            
             <define-assembly name="scope" min-occurs="1" max-occurs="unbounded">
                 <group-as name="scopes" in-json="ARRAY"/>
                 <define-flag name="metaschema-namespace" as-type="uri" required="yes"/>
@@ -1302,6 +1325,10 @@
         <description>Defines constraint rules to be applied to an existing set of Metaschema module-based models.</description>
         <root-name>metaschema-meta-constraints</root-name>
         <model>
+            <assembly ref="metapath-namespace" max-occurs="unbounded">
+                <group-as name="namespace-bindings" />
+            </assembly>
+
             <define-assembly name="definition-context">
                 <define-flag name="name" as-type="token" required="yes"/>
                 <define-flag name="namespace" as-type="uri" required="yes"/>

--- a/schema/metaschema/sarif-module.xml
+++ b/schema/metaschema/sarif-module.xml
@@ -1,0 +1,513 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://raw.githubusercontent.com/usnistgov/metaschema/develop/schema/xml/metaschema.xsd" type="application/xml" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<METASCHEMA xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://csrc.nist.gov/ns/oscal/metaschema/1.0">
+    <schema-name>SARIF Metaschema Module</schema-name>
+    <schema-version>0.1.0</schema-version>
+    <short-name>sarif</short-name>
+    <!-- TODO: Do we want to have 1:1 overlap with SARIF? I am not sure. -->
+    <namespace>https://json.schemastore.org/sarif/2.1.0</namespace>
+    <!-- TODO: Ditto here, this is the URL for the official spec release version. -->
+    <json-base-uri>https://json.schemastore.org/sarif-2.1.0.json</json-base-uri>
+    <define-field name="version">
+        <formal-name>SARIF Model Version</formal-name>
+        <description>The version of the SARIF Model used for conforming instances.</description>
+        <constraint>
+            <allowed-values target="." allow-other="no"> 
+                <enum value="2.1.0"/>
+            </allowed-values>
+        </constraint>
+    </define-field>
+    <define-assembly name="propertyBag">
+        <!-- TODO: review -->
+        <formal-name>Property Bag</formal-name>
+        <description>Key/value pairs that provide additional information about the object.</description>
+        <model>
+	        <define-field name="tag" min-occurs="0" max-occurs="unbounded">
+	        	<formal-name>Tag</formal-name>
+	        	<description>A set of distinct strings that provide additional information.</description>
+	        	<group-as name="tags" in-json="ARRAY"/>
+	        </define-field>
+		</model>
+    </define-assembly>
+    <define-assembly name="toolComponent">
+        <define-flag name="guid" as-type="uuid">
+            <formal-name>Tool Component Unique Identifier</formal-name>
+            <description>A stable, unique identifier for the tool component.</description>
+        </define-flag>
+        <model>
+            <define-field name="name">
+                <formal-name>Tool Component Name</formal-name>
+                <description>The name of the tool component.</description>
+            </define-field>
+            <define-field name="organization" min-occurs="0">
+                <formal-name>Tool Component Organization</formal-name>
+                <description>The organization or company that produced the tool component.</description>
+            </define-field>
+            <define-field name="product" min-occurs="0">
+                <formal-name>Tool Component Product</formal-name>
+                <description>A product suite to which the tool component belongs.</description>
+            </define-field>
+            <define-field name="version" min-occurs="0">
+                <formal-name>Tool Component Version</formal-name>
+                <description>The tool component version, in whatever format the component natively provides.</description>
+            </define-field>
+            <define-field name="semanticVersion" min-occurs="0">
+                <formal-name>Tool Component Semantic Version</formal-name>
+                <description>The tool component version in the format specified by Semantic Versioning 2.0.</description>
+            </define-field>
+            <define-field name="informationUri" as-type="uri" min-occurs="0">
+                <formal-name>Tool Component Information URI</formal-name>
+                <description>The absolute URI at which information about this version of the tool component can be found.</description>
+            </define-field>
+            <assembly ref="reportingDescriptor" min-occurs="0" max-occurs="unbounded">
+            	<formal-name>Rule</formal-name>
+            	<description>An array of reportingDescriptor objects relevant to the analysis performed by the tool component.</description>
+            	<use-name>rule</use-name>
+                <group-as name="rules" in-json="ARRAY" />
+            </assembly>
+        </model>
+    </define-assembly>
+    <define-assembly name="reportingDescriptor">
+        <formal-name>Reporting Descriptor</formal-name>
+        <description>Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting.</description>
+        <define-flag name="id" required="yes">
+            <formal-name>Reporting Descriptor Identifier</formal-name>
+            <description>A stable, opaque identifier for the report.</description>
+        </define-flag>
+        <define-flag name="guid" as-type="uuid">
+            <formal-name>Reporting Descriptor Unique Identifier</formal-name>
+            <description>A stable, unique identifier for the reporting descriptor.</description>
+        </define-flag>
+        <model>
+            <define-field name="name" min-occurs="0">
+                <formal-name>Reporting Descriptor Name</formal-name>
+                <description>A report identifier that is understandable to an end user.</description>
+            </define-field>
+            <assembly ref="multiformatMessageString" min-occurs="0">
+                <formal-name>Short Description</formal-name>
+                <description>A concise description of the report. Should be a single sentence that is understandable when visible space is limited to a single line of text.</description>
+                <use-name>shortDescription</use-name>
+            </assembly>
+            <assembly ref="multiformatMessageString" min-occurs="0">
+                <formal-name>Full Description</formal-name>
+                <description>A description of the report. Should, as far as possible, provide details sufficient to enable resolution of any problem indicated by the result.</description>
+                <use-name>fullDescription</use-name>
+            </assembly>
+            <define-field name="helpUri" as-type="uri" min-occurs="0">
+                <formal-name>Help URI</formal-name>
+                <description>A URI where the primary documentation for the report can be found.</description>
+            </define-field>
+        </model>
+    </define-assembly>
+    <define-assembly name="multiformatMessageString">
+    	<formal-name>Multi-format Message String</formal-name>
+    	<description>A message string or message format string rendered in multiple formats.</description>
+    	<model>
+    	    <define-field name="text" min-occurs="0">
+                <formal-name>Text</formal-name>
+                <description>A plain text message string or format string.</description>
+            </define-field>
+            <define-field name="markdown" min-occurs="0">
+                <formal-name>Markdown</formal-name>
+                <description>A Markdown message string or format string.</description>
+            </define-field>
+        </model>
+    </define-assembly>
+    <define-assembly name="tool">
+        <formal-name>Tool</formal-name>
+        <description>The analysis tool used.</description>
+        <model>
+            <assembly ref="toolComponent">
+                <use-name>driver</use-name>
+                <group-as name="driver"  />
+            </assembly>
+        </model>
+    </define-assembly>
+    <define-assembly name="artifact">
+        <formal-name>Artifacts</formal-name>
+        <description>Artifacts analyzed by the tool to yield results.</description>
+        <model>
+            <assembly ref="artifactLocation" min-occurs="0">
+            	<formal-name>Artifact Location</formal-name>
+            	<description>The location of the artifact.</description>
+            	<use-name>location</use-name>
+            </assembly>
+        </model>
+    </define-assembly>
+    <define-assembly name="result">
+        <formal-name>Results</formal-name>
+        <description>Results from the run of a tool.</description>
+        <define-flag name="ruleId">
+            <formal-name>Rule Identifier</formal-name>
+            <description>The stable, unique identifier of the rule, if any, to which this result is relevant.</description>
+        </define-flag>
+        <define-flag name="ruleIndex" as-type="integer" default="-1">
+            <formal-name>Rule Identifier</formal-name>
+            <description>The stable, unique identifier of the rule, if any, to which this result is relevant.</description>
+        </define-flag>
+        <define-flag name="guid" as-type="uuid">
+            <formal-name>Result Unique Identifier</formal-name>
+            <description>A stable, unique identifier for the result.</description>
+        </define-flag>
+        <model>
+            <assembly ref="reportingDescriptorReference" min-occurs="0">
+                <description>A reference used to locate the rule descriptor relevant to this result.</description>
+                <use-name>rule</use-name>
+            </assembly>
+            <define-field name="kind" min-occurs="0" default="fail">
+                <formal-name>Result Kind</formal-name>
+                <description>A value that categorizes results by evaluation state.</description>
+                <constraint>
+                    <allowed-values target=".">
+                        <enum value="notApplicable"/>
+                        <enum value="pass"/>
+                        <enum value="fail"/>
+                        <enum value="review"/>
+                        <enum value="open"/>
+                        <enum value="informational"/>
+                    </allowed-values>
+                </constraint>
+            </define-field>
+            <define-field name="level" min-occurs="0" default="warning">
+                <formal-name>Severity Level</formal-name>
+                <description>A value specifying the severity level of the result.</description>
+                <constraint>
+                    <allowed-values target=".">
+                        <enum value="none"/>
+                        <enum value="note"/>
+                        <enum value="warning"/>
+                        <enum value="error"/>
+                    </allowed-values>
+                </constraint>
+            </define-field>
+            <assembly ref="message">
+                <formal-name>Result Message</formal-name>
+                <description>A message that describes the result. The first sentence of the message only will be displayed when visible space is limited.</description>
+            </assembly>
+            <assembly ref="artifactLocation" min-occurs="0">
+                <formal-name>Scanned Artifact</formal-name>
+                <description>Identifies the artifact that the analysis tool was instructed to scan. This need not be the same as the artifact where the result actually occurred.</description>
+                <use-name>analysisTarget</use-name>
+            </assembly>
+            <assembly ref="location" min-occurs="0" max-occurs="unbounded">
+                <formal-name>Result Location</formal-name>
+                <description>The set of locations where the result was detected. Specify only one location unless the problem indicated by the result can only be corrected by making a change at every specified location.</description>
+				<use-name>location</use-name>
+                <group-as name="locations" in-json="ARRAY" />
+            </assembly>
+            <define-field name="occurenceCount" as-type="positive-integer" min-occurs="0">
+                <formal-name>Occurrence Count</formal-name>
+                <description>A positive integer specifying the number of times this logically unique result was observed in this run.</description>
+            </define-field>
+            <assembly ref="location" min-occurs="0">
+                <formal-name>Result Related Location</formal-name>
+                <description>A set of locations relevant to this result.</description>
+                <use-name>relatedLocation</use-name>
+                <group-as name="relatedLocations" in-json="ARRAY" />
+            </assembly>
+            <assembly ref="resultProvenance" min-occurs="0">
+                <formal-name>Result Provenance</formal-name>
+                <description>Information about how and when the result was detected.</description>
+                <use-name>provenance</use-name>
+            </assembly>
+        </model>
+        <constraint>
+            <expect target="." test="@ruleIndex &gt;= -1">
+                <message>The value '{ . }' is not greater than or equal to '-1'.</message>
+            </expect>
+            <!-- TODO: unique relatedLocations -->
+        </constraint>
+    </define-assembly>
+    <define-assembly name="reportingDescriptorReference">
+        <formal-name>Reporting Descriptor Reference</formal-name>
+        <description>Information about how to locate a relevant reporting descriptor.</description>
+        <define-flag name="id" required="yes">
+            <formal-name>Reporting Descriptor Identifier</formal-name>
+            <description>The id of the descriptor.</description>
+        </define-flag>
+        <define-flag name="guid" as-type="uuid">
+            <formal-name>Reporting Descriptor Unique Identifier</formal-name>
+            <description>A stable, unique identifier for the reporting descriptor.</description>
+        </define-flag>
+        <model>
+            <define-field name="index" as-type="integer" default="-1" min-occurs="0">
+                <formal-name>Index</formal-name>
+                <description>The index into an array of descriptors in toolComponent.ruleDescriptors, toolComponent.notificationDescriptors, or toolComponent.taxonomyDescriptors, depending on context.</description>
+            </define-field>
+        </model>
+        <constraint>
+            <expect target="." test="@id|@guid|index">
+                <message>At least one id, guid, or index must be provided.</message>
+            </expect>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="message">
+        <formal-name>Message</formal-name>
+        <description>Encapsulates a message intended to be read by the end user.</description>
+        <define-flag name="id" required="yes">
+            <formal-name>Message Identifier</formal-name>
+            <description>The id of the message.</description>
+        </define-flag>
+        <model>
+            <define-field name="text" min-occurs="0">
+                <formal-name>Text</formal-name>
+                <description>A plain text message string.</description>
+            </define-field>
+            <define-field name="markdown" min-occurs="0">
+                <formal-name>Markdown</formal-name>
+                <description>A Markdown message string.</description>
+            </define-field>
+            <define-field name="argument" min-occurs="0" max-occurs="unbounded">
+                <formal-name>Argument</formal-name>
+                <description>A sequence of strings to substitute into the message string.</description>
+                <group-as name="arguments" in-json="ARRAY" />
+            </define-field>
+        </model>
+        <constraint>
+            <expect target="." test="@id|text">
+                <message>At least one id or text must be provided.</message>
+            </expect>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="artifactLocation">
+        <formal-name>Artifact Location</formal-name>
+        <description>Specifies the location of an artifact.</description>
+        <model>
+            <define-field name="uri" as-type="uri-reference" min-occurs="0">
+                <formal-name>URI</formal-name>
+                <description>A valid relative or absolute URI.</description>
+            </define-field>
+            <define-field name="index" as-type="integer"  min-occurs="0" default="-1">
+				<formal-name>Index</formal-name>
+				<description>The index within the run artifacts array of the artifact object associated with the artifact location.</description>
+    		    <constraint>
+                    <expect target="." test="@id &gt;= -1">
+                        <message>The index '{ . }' is not greater than or equal to '-1'.</message>
+                    </expect>
+                </constraint>
+            </define-field>
+            <assembly ref="message" min-occurs="0">
+                <formal-name>Description</formal-name>
+                <description>A short description of the artifact location.</description>
+                <use-name>description</use-name>
+            </assembly>
+        </model>
+    </define-assembly>
+    <define-assembly name="location">
+        <formal-name>Location</formal-name>
+        <description>A location within a programming artifact.</description>
+        <define-flag name="id" as-type="integer" default="-1">
+            <formal-name>Location Identifier</formal-name>
+            <description>A value that distinguishes this location from all other locations within a single result object.</description>
+        </define-flag>
+        <model>
+            <assembly ref="physicalLocation" min-occurs="0">
+                <formal-name>Physical Location</formal-name>
+                <description>A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.</description>
+            </assembly>
+            <assembly ref="logicalLocation">
+                <formal-name>Logical Location</formal-name>
+                <description>The logical locations associated with the result.</description>
+            </assembly>
+            <assembly ref="message">
+                <formal-name>Location Message</formal-name>
+                <description>A message relevant to the location.</description>
+            </assembly>
+        </model>
+        <constraint>
+            <expect target="." test="@id &gt;= -1">
+                <message>The id '{ . }' is not greater than or equal to '-1'.</message>
+            </expect>
+            <!-- TODO: unique relatedLocations -->
+        </constraint>
+    </define-assembly>
+    <define-assembly name="physicalLocation">
+        <formal-name>Physical Location</formal-name>
+        <description>A physical location relevant to a result. Specifies a reference to a programming artifact together with a range of bytes or characters within that artifact.</description>
+        <model>
+            <define-assembly name="address" min-occurs="0">
+                <formal-name>Address</formal-name>
+                <description>A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).</description>
+                <!-- TODO -->
+            </define-assembly>
+            <assembly ref="artifactLocation" min-occurs="0">
+                <description>The location of the artifact.</description>
+            </assembly>
+            <assembly ref="region" min-occurs="0">
+                <formal-name>Region</formal-name>
+                <description>Specifies a portion of the artifact.</description>
+            </assembly>
+            <assembly ref="region" min-occurs="0">
+                <formal-name>Context Region</formal-name>
+                <description>Specifies a portion of the artifact that encloses the region. Allows a viewer to display additional context around the region.</description>
+                <use-name>contextRegion</use-name>
+            </assembly>
+        </model>
+        <constraint>
+            <expect target="." test="address|artifactLocation">
+                <message>At least one address or artifactLocation must be provided.</message>
+            </expect>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="logicalLocation">
+    	<formal-name>Logical Location</formal-name>
+    	<description>A logical location of a construct that produced a result.</description>
+    	<model>
+    		<define-field name="name" min-occurs="0">
+    			<formal-name>Logical Location Name</formal-name>
+    			<description>Identifies the construct in which the result occurred. For example, this property might contain the name of a class or a method.</description>
+    		</define-field>
+    		<define-field name="index" as-type="integer"  min-occurs="0" default="-1">
+				<formal-name>Index</formal-name>
+				<description>The index within the logical locations array.</description>
+    		    <constraint>
+                    <expect target="." test="@id &gt;= -1">
+                        <message>The index '{ . }' is not greater than or equal to '-1'.</message>
+                    </expect>
+                </constraint>
+            </define-field>
+            <define-field name="fullyQualifiedName">
+            	<formal-name>Fully Qualified Name</formal-name>
+            	<description>The human-readable fully qualified name of the logical location.</description>
+            </define-field>
+            <define-field name="decoratedName">
+            	<formal-name>Decorated Name</formal-name>
+            	<description>The machine-readable name for the logical location, such as a mangled function name provided by a C++ compiler that encodes calling convention, return type and other details along with the function name.</description>
+            </define-field>
+            <define-field name="parentIndex" as-type="integer"  min-occurs="0" default="-1">
+            	<formal-name>Parent Index</formal-name>
+            	<description>Identifies the index of the immediate parent of the construct in which the result was detected. For example, this property might point to a logical location that represents the namespace that holds a type.</description>
+            	<constraint>
+                    <expect target="." test="@id &gt;= -1">
+                        <message>The index '{ . }' is not greater than or equal to '-1'.</message>
+                    </expect>
+                </constraint>
+            </define-field>
+            <define-field name="kind">
+            	<formal-name>Kind</formal-name>
+            	<description>The type of construct this logical location component refers to. Should be one of 'function', 'member', 'module', 'namespace', 'parameter', 'resource', 'returnType', 'type', 'variable', 'object', 'array', 'property', 'value', 'element', 'text', 'attribute', 'comment', 'declaration', 'dtd' or 'processingInstruction', if any of those accurately describe the construct.</description>
+            </define-field>
+    	</model>
+    </define-assembly>
+    <define-assembly name="region">
+        <formal-name>Region</formal-name>
+        <description>A region within an artifact where a result was detected.</description>
+        <model>
+            <define-field name="startLine" as-type="positive-integer" min-occurs="0">
+                <formal-name>Start Line</formal-name>
+                <description>The line number of the first character in the region.</description>
+            </define-field>
+      
+            <define-field name="startColumn" as-type="positive-integer" min-occurs="0">
+                <formal-name>Start Column</formal-name>
+                <description>The column number of the first character in the region.</description>
+            </define-field>
+      
+            <define-field name="endLine" as-type="positive-integer" min-occurs="0">
+                <formal-name>End Line</formal-name>
+                <description>The line number of the last character in the region.</description>
+            </define-field>
+      
+            <define-field name="endColumn" as-type="positive-integer" min-occurs="0">
+                <formal-name>End Column</formal-name>
+                <description>The column number of the character following the end of the region.</description>
+            </define-field>
+      
+            <define-field name="charOffset" as-type="integer" default="-1" min-occurs="0">
+                <formal-name>Character Offset</formal-name>
+                <description>The zero-based offset from the beginning of the artifact of the first character in the region.</description>
+                <constraint>
+                    <expect target="." test="@id &gt;= -1">
+                        <message>The offset '{ . }' is not greater than or equal to '-1'.</message>
+                    </expect>
+                </constraint>
+            </define-field>
+      
+            <define-field name="charLength" as-type="non-negative-integer" min-occurs="0">
+                <formal-name>Character Length</formal-name>
+                <description>The length of the region in characters.</description>
+            </define-field>
+      
+            <define-field name="byteOffset" as-type="integer" default="-1" min-occurs="0">
+                <formal-name>Byte Offset</formal-name>
+                <description>The zero-based offset from the beginning of the artifact of the first byte in the region</description>
+                <constraint>
+                    <expect target="." test="@id &gt;= -1">
+                        <message>The offset '{ . }' is not greater than or equal to '-1'.</message>
+                    </expect>
+                </constraint>
+            </define-field>
+      
+            <define-field name="byteLength" as-type="non-negative-integer" min-occurs="0">
+                <formal-name>Byte Length</formal-name>
+                <description>The length of the region in bytes.</description>
+            </define-field>
+      
+            <assembly ref="message">
+                <formal-name>Region Message</formal-name>
+                <description>A message relevant to the region.</description>
+            </assembly>
+        </model>
+        <constraint>
+            <expect target="." test="startLine|charOffset|byteOffset">
+                <message>At least a startLine, charOffset, or byteOffset must be provided.</message>
+            </expect>
+        </constraint>
+    </define-assembly>
+    <define-assembly name="resultProvenance">
+        <formal-name>Result Provanance</formal-name>
+        <description>Contains information about how and when a result was detected.</description>
+        <model>
+            <define-field name="firstDetectionTimeUtc" as-type="date-time-with-timezone" min-occurs="0">
+                <formal-name>First Detection Time</formal-name>
+                <description>The Coordinated Universal Time (UTC) date and time at which the result was first detected. See \"Date/time properties\" in the SARIF spec for the required format.</description>
+            </define-field>
+
+            <define-field name="lastDetectionTimeUtc" as-type="date-time-with-timezone" min-occurs="0">
+                <formal-name>Last Detection Time</formal-name>
+                <description>The Coordinated Universal Time (UTC) date and time at which the result was most recently detected. See \"Date/time properties\" in the SARIF spec for the required format.</description>
+            </define-field>
+
+            <assembly ref="physicalLocation" min-occurs="0" max-occurs="unbounded">
+                <formal-name>Conversion Source</formal-name>
+                <description>An sequence of physicalLocation objects which specify the portions of an analysis tool's output that a converter transformed into the result.</description>
+                <use-name>conversionSource</use-name>
+                <group-as name="conversionSources" in-json="ARRAY" />
+            </assembly>
+        </model>
+    </define-assembly>
+    <define-assembly name="run">
+        <formal-name>Run</formal-name>
+        <description>Describes a single run of an analysis tool, and contains the reported output of that run.</description>
+        <model>
+            <assembly ref="tool">
+                <formal-name>Tool</formal-name>
+                <description>Information about the tool or tool pipeline that generated the results in this run. A run can only contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple log files, as long as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files.</description>
+            </assembly>
+            <assembly ref="artifact" min-occurs="0" max-occurs="unbounded">
+                <formal-name>Artifact</formal-name>
+                <description>A sequence of artifacts relevant to the run.</description>
+                <group-as name="artifacts" in-json="ARRAY" />
+            </assembly>
+            <assembly ref="result" min-occurs="0" max-occurs="unbounded">
+                <formal-name>Result</formal-name>
+                <description>The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting rules metadata. It must be present (but may be empty) if a log file represents an actual scan.</description>
+                <group-as name="results" in-json="ARRAY" />
+            </assembly>
+        </model>
+    </define-assembly>
+    <define-assembly name="sarif">
+        <formal-name>Static Analysis Results Interchange Format</formal-name>
+        <description>A standard format for the output of static analysis tools.</description>
+        <root-name>sarif</root-name>
+        <model>
+            <field ref="version" max-occurs="1"/>
+            <assembly ref="run" max-occurs="unbounded">
+                <group-as name="runs" in-json="ARRAY" />
+            </assembly>
+        </model>
+        <remarks>
+            <p>Note, Metaschema does not support an anonymous top-level assembly without a key name in JSON and YAML, which is required for SARIF.</p>
+        </remarks>
+    </define-assembly>
+</METASCHEMA>

--- a/schema/xml/metaschema-meta-constraints.xsd
+++ b/schema/xml/metaschema-meta-constraints.xsd
@@ -11,6 +11,7 @@
     <xs:element name="metaschema-meta-constraints">
         <xs:complexType>
             <xs:sequence>
+                <xs:element name="namespace-binding" type="NamespaceBindingType" minOccurs="0" maxOccurs="unbounded"/> 
                 <xs:element name="context" type="ModelContextType" maxOccurs="unbounded"/>
             </xs:sequence>
         </xs:complexType>

--- a/schema/xml/metaschema.xsd
+++ b/schema/xml/metaschema.xsd
@@ -45,6 +45,8 @@
 
         <xs:element name="import" type="MetaschemaImportType" minOccurs="0" maxOccurs="unbounded"/>
 
+		<xs:element name="namespace-binding" type="NamespaceBindingType" minOccurs="0" maxOccurs="unbounded"/> 
+
         <xs:choice minOccurs="0" maxOccurs="unbounded">
           <xs:element name="define-assembly" type="GlobalAssemblyDefinitionType"/>
           <xs:element name="define-field" type="GlobalFieldDefinitionType"/>
@@ -78,6 +80,22 @@
         <xs:documentation>A relative or absolute URI for retrieving an out-of-line Metaschema definition.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="NamespaceBindingType">
+  	<xs:annotation>
+      <xs:documentation>Assigns a Metapath namespace to a prefix for use in a Metapath expression in a lexical qualified name.</xs:documentation>
+  	</xs:annotation>
+	<xs:attribute name="prefix" type="TokenDatatype" use="required">
+      <xs:annotation>
+        <xs:documentation>The prefix that is bound to the namespace.</xs:documentation>
+      </xs:annotation>
+	</xs:attribute>
+	<xs:attribute name="uri" type="URIDatatype" use="required">
+      <xs:annotation>
+        <xs:documentation>The namespace URI to bind to the prefix.</xs:documentation>
+      </xs:annotation>
+	</xs:attribute>
   </xs:complexType>
 
   <xs:group name="DefinitionMetadataGroup">
@@ -1303,6 +1321,7 @@
             </xs:attribute>
           </xs:complexType>
         </xs:element>
+        <xs:element name="namespace-binding" type="NamespaceBindingType" minOccurs="0" maxOccurs="unbounded"/> 
         <xs:element name="scope" maxOccurs="unbounded">
           <xs:complexType>
             <xs:choice maxOccurs="unbounded">

--- a/test-suite/schema-generation/datatypes/datatypes-numeric_metaschema.xml
+++ b/test-suite/schema-generation/datatypes/datatypes-numeric_metaschema.xml
@@ -17,11 +17,11 @@
             <formal-name>Integer</formal-name>
             <description>Per W3C</description>
          </define-field>
-         <define-field name="posInt" as-type="positiveInteger" min-occurs="1" max-occurs="1">
+         <define-field name="posInt" as-type="positive-integer" min-occurs="1" max-occurs="1">
             <formal-name>Positive Integer</formal-name>
             <description>1 or more</description>
          </define-field>
-         <define-field name="nonNegInt" as-type="nonNegativeInteger" min-occurs="1" max-occurs="1">
+         <define-field name="nonNegInt" as-type="non-negative-integer" min-occurs="1" max-occurs="1">
             <formal-name>Non-negative Integer</formal-name>
             <description>zero or more</description>
          </define-field>

--- a/test-suite/worked-examples/anthology/anthology_metaschema.xml
+++ b/test-suite/worked-examples/anthology/anthology_metaschema.xml
@@ -19,7 +19,7 @@
        <description>A <b>collection</b> of literary excerpts</description>
        <root-name>ANTHOLOGY</root-name>
        <flag ref="id"/>
-       <define-flag name="fans" as-type="nonNegativeInteger">
+       <define-flag name="fans" as-type="non-negative-integer">
            <formal-name>fans</formal-name>
            <description>How many fans?</description>
        </define-flag>

--- a/website/content/specification/syntax/datatypes.md
+++ b/website/content/specification/syntax/datatypes.md
@@ -1,0 +1,835 @@
+---
+title: "Metaschema Data Types"
+linkTitle: "Data Types"
+description: "A description of the built in data types supported by Metaschema."
+weight: 60
+---
+
+# Data Types Used in Metaschema
+
+Metaschema is a strongly typed modeling language, that uses a collection of built in data types to represent data elements within a Metaschema-based model.
+
+Metaschema's data types represent a data-oriented, leaf nodes in a Metaschema-based model. These data types provide the basis for data elements that have clearly defined syntax and semantics.
+
+
+There are 2 kinds of data types.
+
+- **[simple data types:](#simple-data-types)** that represent basic data value primitives with a specific syntax and semantics.
+- **[markup data types:](#markup-data-types)** that represent semantically formatted text that is intended for presentation.
+
+A data type can be referenced in a metaschema definition within a `define-field`, `field`, `define-flag`, or `flag` component definition using the `@as-type` attribute. The following are the allowed data types.
+
+## Data Type Schema Representations
+
+JSON and XML Schema instances are provided for the built in data types.
+
+### JSON Schema
+
+A single JSON schema is [provided](https://github.com/usnistgov/metaschema/blob/develop/schema/json/metaschema-datatypes.json) for all built in data types supporting JSON and YAML validation. This schema is based on JSON Schema draft-07 ([JSON Schema](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-01) and [JSON Schema Validation 01](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01)).
+
+The data type JSON schema uses regular expression patterns to enforce the syntax of specific data types. The regular expressions supported in JSON schema using the [`pattern`](https://datatracker.ietf.org/doc/html/draft-handrews-json-schema-validation-01#section-6.3.3) keyword are based on the [ECMA 262 regular expression dialect](https://262.ecma-international.org/#sec-regexp-regular-expression-objects).
+
+### XML Schemas
+
+Multiple XML Schemas are provided that support different groups of data types.
+
+The [Simple data types](#simple-data-types) are defined in [a single XML Schema](https://github.com/usnistgov/metaschema/blob/develop/schema/xml/metaschema-datatypes.xsd).
+
+The [markup data types](#markup-data-types) are supported by multiple schemas.
+
+The [`markup-line`](#markup-line) data type is implemented in XML Schema within the [metaschema-markup-line.xsd](https://github.com/usnistgov/metaschema/blob/develop/schema/xml/metaschema-markup-line.xsd) schema.
+
+The [`markup-multiline`](#markup-multiline) data type is implemented in XML Schema within the [metaschema-markup-multiline.xsd](https://github.com/usnistgov/metaschema/blob/develop/schema/xml/metaschema-markup-multiline.xsd) schema.
+
+Both of these schemas use a set of shared XML Schema types from the [metaschema-prose-base.xsd](https://github.com/usnistgov/metaschema/blob/develop/schema/xml/metaschema-prose-base.xsd).
+
+The [metaschema-prose-module.xsd](https://github.com/usnistgov/metaschema/blob/develop/schema/xml/metaschema-prose-module.xsd) XML schema is provided as a convenience to support use of both the `markup-line` and `markup-multiline` data types.
+
+XML Schema uses its [own dialect](https://www.w3.org/TR/xmlschema-2/#regexs) of regular expressions.
+
+### Regular Expressions in Schemas
+
+Regular expressions used in JSON and XML Schemas use a reduced subset of regular expression syntax that is intended to be well supported by most regular expression dialects.
+
+Regular expression features used include:
+
+- Single line matching
+- Unicode characters
+- Grouping
+- Character classes, including use of Unicode property value expressions (e.g., `\p{L}`, `\p{N}`)
+- Class ranges
+- Class negation
+- Quantifiers
+
+These features tend to be widely supported by implementations based on the [Perl Compatible Regular Expression (PCRE)](https://www.pcre.org/), [ECMA](https://262.ecma-international.org/#sec-regexp-regular-expression-objects), [Java](https://cr.openjdk.org/~iris/se/19/latestSpec/api/java.base/java/util/regex/Pattern.html), and [XML Schema 1.0](https://www.w3.org/TR/xmlschema-2/#regexs) regex dialects. As a result, implementations based on any of these standards should be able to support the patterns used in the Metaschema JSON and XML data type schemas.
+
+## Simple Data Types
+
+{{<callout>}}Prior to Metaschema 1.0.0, simple data types used [camelCase style names](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case) (i.e. `positiveInteger`; `dateTime`). The camelCase names are deprecated in version 1.0.0 and newer. Metaschema 1.0.0 and newer only support [kebab-case style names](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) (i.e. `positive-integer`; `date-time`).{{</callout>}}
+
+These data types represent the basic data primitives used in Metaschema to support different types of data values.
+
+- **numeric values:** [decimal](#decimal), [integer](#integer), [non-negative-integer](#non-negative-integer), [positive-integer](#positive-integer)
+- **temporal values:** [date](#date), [date-with-timezone](#date-with-timezone), [date-time](#date-time), [date-time-with-timezone](#date-time-with-timezone), [day-time-duration](#day-time-duration), [year-month-duration](#year-month-duration)
+- **binary values:** [base64](#base64), [boolean](#boolean)
+- **character-based values:** [email-address](#email-address), [hostname](#hostname), [ip-v4-address](#ip-v4-address), [ip-v6-address](#ip-v6-address), [string](#string), [token](#token), [uri](#uri), [uri-reference](#uri-reference), [uuid](#uuid)
+
+Details of these data types follow.
+
+### base64
+
+A string representing arbitrary binary data encoded using the [Base 64 algorithm](https://www.rfc-editor.org/rfc/rfc4648#section-4) as defined by [RFC4648](https://www.rfc-editor.org/rfc/rfc4648).
+
+In XML Schema this is represented as a restriction of the built-in type [base64Binary](https://www.w3.org/TR/xmlschema11-2/#base64Binary) that doesn't allow leading and trailing whitespace.
+
+This data type is defined in XML as follows:
+
+```XML
+<xs:simpleType name="Base64Datatype">
+  <xs:restriction base="xs:base64Binary">
+    <xs:pattern value="[0-9A-Za-z+/]+={0,2}">
+      <xs:annotation>
+        <xs:documentation>A trimmed string, at least one character with no
+          leading or trailing whitespace.</xs:documentation>
+      </xs:annotation>
+    </xs:pattern>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "pattern": "^[0-9A-Za-z+/]+={0,2}$",
+  "contentEncoding": "base64"
+}
+```
+
+### boolean
+
+A boolean value mapped in XML, JSON, and YAML as follows:
+
+| Value | XML | JSON | YAML |
+|:--- |:--- |:--- |:--- |
+| true | `true` or `1` | `true` | `true` |
+| false | `false` or `0` | `false` | `false` |
+
+In XML Schema this is represented as a restriction on the built-in type [boolean](https://www.w3.org/TR/xmlschema11-2/#boolean) as follows:
+
+```XML
+<xs:simpleType name="BooleanDatatype">
+  <xs:restriction base="xs:boolean">
+    <xs:pattern value="true|false|0|1"/>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+The pattern `true|false|0|1` above ensures that leading and trailing whitespace is not allowed in XML-based Metaschema instances using this data type.
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "boolean"
+}
+```
+
+### date
+
+A string representing a 24-hour period, optionally qualified by a timezone. A `date-with-timezone` is formatted according to "full-date" as defined [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6), with the addition of an optional timezone, specified as a time-offset according to RFC3339.
+
+This is the same as [date-with-timezone](#date-with-timezone), except the timezone portion is optional. This can be used to support formats that have ambiguous timezones for date values.
+
+For example:
+
+```
+2019-09-28Z
+2019-09-28
+2019-12-02-08:00
+2019-12-02
+```
+
+In XML Schema this is represented as a restriction on the built-in type [date](https://www.w3.org/TR/xmlschema11-2/#date) as follows:
+
+```XML
+<xs:simpleType name="DateDatatype">
+  <xs:restriction base="xs:date">
+    <xs:pattern value="(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))(Z|[+-][0-9]{2}:[0-9]{2})?" />
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "pattern": "^(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))(Z|[+-][0-9]{2}:[0-9]{2})?$"
+}
+```
+
+### date-with-timezone
+
+A string representing a 24-hour period in a given timezone. A `date-with-timezone` is formatted according to "full-date" as defined [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6), with the addition of a timezone, specified as a time-offset according to RFC3339.
+
+This type requires that the time-offset (timezone) is always provided. This use of timezone ensure that date information exchanged across timezones is unambiguous.
+
+For example:
+
+```
+2019-09-28Z
+2019-12-02-08:00
+```
+
+In XML Schema this is represented as a restriction on the built-in type [date](https://www.w3.org/TR/xmlschema11-2/#date) as follows:
+
+```XML
+<xs:simpleType name="DateWithTimezoneDatatype">
+  <xs:restriction base="DateDatatype">
+    <xs:pattern value="(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))(Z|[+-][0-9]{2}:[0-9]{2})" />
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "pattern": "^(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))(Z|[+-][0-9]{2}:[0-9]{2})$"
+}
+```
+
+### date-time
+
+A string representing a point in time, optionally qualified by a timezone. This date and time value is formatted according to "date-time" as defined [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6), except the timezone (time-offset) is optional.
+
+This is the same as [date-time-with-timezone](#date-time-with-timezone), except the timezone portion is optional. This can be used to support formats that have ambiguous timezones for date/time values.
+
+
+For example:
+
+```
+2019-09-28T23:20:50.52Z
+2019-09-28T23:20:50.52
+2019-09-28T23:20:50.1000
+2019-12-02T16:39:57-08:00
+2019-12-02T16:39:57
+2019-12-31T23:59:59Z
+2019-12-31T23:59:59
+```
+
+In XML Schema this is represented as a restriction on the built-in type [dateTime](https://www.w3.org/TR/xmlschema11-2/#dateTime) as follows:
+
+```XML
+<xs:simpleType name="DateTimeDatatype">
+  <xs:restriction base="xs:dateTime">
+    <xs:pattern value="(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|(-((0[0-9]|1[0-2]):00|0[39]:30)|\+((0[0-9]|1[0-4]):00|(0[34569]|10):30|(0[58]|12):45)))?" />
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "pattern": "^(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|(-((0[0-9]|1[0-2]):00|0[39]:30)|\\+((0[0-9]|1[0-4]):00|(0[34569]|10):30|(0[58]|12):45)))?$"
+}
+```
+
+### date-time-with-timezone
+
+A string representing a point in time in a given timezone. This date and time value is formatted according to "date-time" as defined [RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6).
+
+This type requires that the time-offset (timezone) is always provided. This use of timezone ensures that date/time information exchanged across timezones is unambiguous.
+
+For example:
+
+```
+2019-09-28T23:20:50.52Z
+2019-09-28T23:20:50.520Z
+2019-12-02T16:39:57-08:00
+2019-12-31T23:59:59Z
+```
+
+In XML Schema this is represented as a restriction on the built in type [dateTime](https://www.w3.org/TR/xmlschema11-2/#dateTime) as follows:
+
+```XML
+<xs:simpleType name="DateWithTimezoneDatatype">
+  <xs:restriction base="DateDatatype">
+    <xs:pattern value="(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|(-((0[0-9]|1[0-2]):00|0[39]:30)|\+((0[0-9]|1[0-4]):00|(0[34569]|10):30|(0[58]|12):45)))" />
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "format": "date-time",
+  "pattern": "^(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|(-((0[0-9]|1[0-2]):00|0[39]:30)|\\+((0[0-9]|1[0-4]):00|(0[34569]|10):30|(0[58]|12):45)))$"
+}
+```
+
+### day-time-duration
+
+An amount of time quantified in days, hours, minutes, and seconds based on [ISO-8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (see also [RFC3339 appendix A](https://www.rfc-editor.org/rfc/rfc3339.html#appendix-A)).
+
+Examples include:
+
+The duration of 1 day, 12 hours, and 45 minutes can be represented as:
+
+```
+P1DT12H45M
+```
+
+The using the optional minus sign, the negative duration of 3 hours can be represented as:
+
+```
+-PT3H
+```
+
+In XML Schema this is defined by [dayTimeDuration](https://www.w3.org/TR/xmlschema11-2/#dayTimeDuration), which is a restriction on the built-in type [duration](https://www.w3.org/TR/xmlschema11-2/#duration) as follows:
+
+```XML
+<xs:simpleType name="DayTimeDurationDatatype">
+  <xs:restriction base="xs:duration">
+    <xs:pattern value="-?P([0-9]+D(T(([0-9]+H([0-9]+M)?(([0-9]+|[0-9]+(\.[0-9]+)?)S)?)|([0-9]+M(([0-9]+|[0-9]+(\.[0-9]+)?)S)?)|([0-9]+|[0-9]+(\.[0-9]+)?)S))?)|T(([0-9]+H([0-9]+M)?(([0-9]+|[0-9]+(\.[0-9]+)?)S)?)|([0-9]+M(([0-9]+|[0-9]+(\.[0-9]+)?)S)?)|([0-9]+|[0-9]+(\.[0-9]+)?)S)"/>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "format": "duration",
+  "pattern": "^-?P([0-9]+D(T(([0-9]+H([0-9]+M)?(([0-9]+|[0-9]+(\\.[0-9]+)?)S)?)|([0-9]+M(([0-9]+|[0-9]+(\\.[0-9]+)?)S)?)|([0-9]+|[0-9]+(\\.[0-9]+)?)S))?)|T(([0-9]+H([0-9]+M)?(([0-9]+|[0-9]+(\\.[0-9]+)?)S)?)|([0-9]+M(([0-9]+|[0-9]+(\\.[0-9]+)?)S)?)|([0-9]+|[0-9]+(\\.[0-9]+)?)S)$"
+}
+```
+
+### decimal
+
+A real number expressed using a whole and optional fractional part separated by a period.
+
+In XML Schema this is represented as a restriction on the built-in type [decimal](https://www.w3.org/TR/xmlschema11-2/#decimal) as follows:
+
+```XML
+<xs:simpleType name="DecimalDatatype">
+  <xs:restriction base="xs:decimal">
+    <xs:pattern value="\S(.*\S)?"/>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "number",
+  "pattern": "(\\+|-)?([0-9]+(\\.[0-9]*)?|\\.[0-9]+)"
+}
+```
+### email-address
+
+An email address string formatted according to [RFC6531](https://tools.ietf.org/html/rfc6531).
+
+In XML Schema this is represented as a restriction on the built in type [string](https://www.w3.org/TR/xmlschema11-2/#string) as follows:
+
+```XML
+<xs:simpleType name="EmailAddressDatatype">
+  <xs:restriction base="StringDatatype">
+    <xs:pattern value="\S.*@.*\S">
+      <xs:annotation>
+        <xs:documentation>Need a better pattern.</xs:documentation>
+      </xs:annotation>
+    </xs:pattern>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "format": "email",
+  "pattern": "^.+@.+$"
+}
+```
+
+### hostname
+
+An internationalized Internet host name string formatted according to [section 2.3.2.3](https://tools.ietf.org/html/rfc5890#section-2.3.2.3) of RFC5890.
+
+In XML Schema this is represented as a restriction on the built in type [string](https://www.w3.org/TR/xmlschema11-2/#string) as follows:
+
+```XML
+<xs:simpleType name="HostnameDatatype">
+  <xs:restriction base="StringDatatype"/>
+</xs:simpleType>
+```
+
+**Note: A better pattern is needed for normalizing hostname, since the current data type is very open-ended.**
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "pattern": "^\\S(.*\\S)?$",
+  "format": "idn-hostname"
+}
+```
+
+Once a suitable pattern for XML is developed, this pattern will be ported to JSON for more consistent validation.
+
+### integer
+
+A whole number value.
+
+In XML Schema this is represented as a restriction on the built-in type [integer](https://www.w3.org/TR/xmlschema11-2/#integer) as follows:
+
+```XML
+<xs:simpleType name="IntegerDatatype">
+  <xs:restriction base="xs:integer">
+    <xs:pattern value="\S(.*\S)?" />
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "integer"
+}
+```
+
+### ip-v4-address
+
+An Internet Protocol version 4 address represented using dotted-quad syntax as defined in [section 3.2](https://tools.ietf.org/html/rfc2673#section-3.2) of RFC2673.
+
+In XML Schema this is represented as a restriction on the built in type [string](https://www.w3.org/TR/xmlschema11-2/#string) as follows:
+
+```XML
+<xs:simpleType name="IPV4AddressDatatype">
+  <xs:restriction base="StringDatatype">
+    <xs:pattern value="((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])" />
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "format": "ipv4",
+  "pattern": "^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])$"
+}
+```
+
+### ip-v6-address
+
+An Internet Protocol version 6 address represented using the syntax defined in [section 2.2](https://tools.ietf.org/html/rfc3513#section-2.2) of RFC3513.
+
+In XML Schema this is represented as a restriction on the built in type [string](https://www.w3.org/TR/xmlschema11-2/#string) as follows:
+
+```XML
+<xs:simpleType name="IPV6AddressDatatype">
+  <xs:restriction base="xs:string">
+    <xs:whiteSpace value="collapse"/>
+    <xs:pattern value="(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|[fF][eE]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::([fF]{4}(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3,3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3,3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]))" />
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "format": "ipv6",
+  "pattern": "^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|[fF][eE]80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::([fF]{4}(:0{1,4}){0,1}:){0,1}((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3,3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]).){3,3}(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9]))$"
+}
+```
+
+### non-negative-integer
+
+An integer value that is equal to or greater than `0`.
+
+In XML Schema this is represented as a restriction on the built-in type [nonNegativeInteger](https://www.w3.org/TR/xmlschema11-2/#nonNegativeInteger) as follows:
+
+```XML
+<xs:simpleType name="NonNegativeIntegerDatatype">
+  <xs:restriction base="xs:nonNegativeInteger">
+    <xs:pattern value="\S(.*\S)?"/>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+Note: The pattern above ensures that leading and trailing whitespace is not allowed in XML-based Metaschema instances using this data type.
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "integer",
+  "minimum": 0
+}
+```
+
+### positive-integer
+
+An integer value that is greater than `0`.
+
+In XML Schema this is represented as a restriction on the built-in type [positiveInteger](https://www.w3.org/TR/xmlschema11-2/#nonNegativeInteger) as follows:
+
+```XML
+<xs:simpleType name="PositiveIntegerDatatype">
+  <xs:restriction base="xs:positiveInteger">
+    <xs:pattern value="\S(.*\S)?" />
+  </xs:restriction>
+</xs:simpleType>
+```
+
+Note: The pattern above ensures that leading and trailing whitespace is not allowed in XML-based Metaschema instances using this data type.
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "integer",
+  "minimum": 1
+}
+```
+
+### string
+
+A non-empty string of unicode characters with leading and trailing whitespace disallowed.
+
+Whitespace is: `U+9`, `U+10`, `U+32` or `[ \n\t]+`.
+
+In XML Schema this is represented as a restriction on the built in type [string](https://www.w3.org/TR/xmlschema11-2/#string) as follows:
+
+```XML
+<xs:simpleType name="StringDatatype">
+  <xs:restriction base="xs:string">
+    <xs:whiteSpace value="preserve"/>
+    <xs:pattern value="\S(.*\S)?"/>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+Note: The pattern above ensures that leading and trailing whitespace is not allowed in XML-based Metaschema instances using this data type.
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "pattern": "^\\S(.*\\S)?$"
+}
+```
+
+### token
+
+A non-colonized name as defined by [XML Schema Part 2: Datatypes Second Edition](https://www.w3.org/TR/xmlschema11-2/#NCName).
+
+In XML Schema this is represented as a restriction on the built in type [string](https://www.w3.org/TR/xmlschema11-2/#string) as follows:
+
+```XML
+<xs:simpleType name="TokenDatatype">
+  <xs:restriction base="StringDatatype">
+    <xs:pattern value="(\p{L}|_)(\p{L}|\p{N}|[.\-_])*"/>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "pattern": "^(\\p{L}|_)(\\p{L}|\\p{N}|[.\\-_])*$"
+}
+```
+
+### uri
+
+A universal resource identifier (URI) formatted according to [RFC3986](https://tools.ietf.org/html/rfc3986).
+
+In XML Schema this is represented as a restriction on the built in type [anyURI](https://www.w3.org/TR/xmlschema11-2/#anyURI) as follows:
+
+```XML
+<xs:simpleType name="URIDatatype">
+  <xs:restriction base="xs:anyURI">
+    <xs:pattern value="[a-zA-Z][a-zA-Z0-9+\-.]+:.*\S">
+      <xs:annotation>
+        <xs:documentation>Requires a scheme with colon per RFC3986.</xs:documentation>
+      </xs:annotation>
+    </xs:pattern>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "format": "uri",
+  "pattern": "^[a-zA-Z][a-zA-Z0-9+\\-.]+:.+$"
+}
+```
+
+### uri-reference
+
+A URI Reference, either a URI or a relative-reference, formatted according to [section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1) of RFC3986.
+
+In XML Schema this is represented as a restriction on the built in type [anyURI](https://www.w3.org/TR/xmlschema11-2/#anyURI) as follows:
+
+```XML
+<xs:simpleType name="URIReferenceDatatype">
+  <xs:annotation>
+    <xs:documentation>A trimmed URI having at least one character with no
+      leading or trailing whitespace.</xs:documentation>
+  </xs:annotation>
+  <xs:restriction base="xs:anyURI">
+    <xs:pattern value="\S(.*\S)?"/>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+Note: The pattern above ensures that leading and trailing whitespace is not allowed in XML-based Metaschema instances using this data type.
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "format": "uri-reference"
+}
+```
+
+### uuid
+
+A version 4 or 5 Universally Unique Identifier (UUID) as defined by [RFC4122](https://tools.ietf.org/html/rfc4122).
+
+In XML Schema this is represented as a restriction on the built in type [string](https://www.w3.org/TR/xmlschema11-2/#string) as follows:
+
+```XML
+<xs:simpleType name="UUIDDatatype">
+  <xs:restriction base="StringDatatype">
+    <xs:pattern value="[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[45][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}">
+      <xs:annotation>
+        <xs:documentation>A sequence of 8-4-4-4-12 hex digits, with
+          extra constraints in the 13th and 17-18th places for version
+          4 and 5.</xs:documentation>
+      </xs:annotation>
+    </xs:pattern>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[45][0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$"
+}
+```
+
+### year-month-duration
+
+An amount of time quantified in years and months based on [ISO-8601 durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (see also [RFC3339 appendix A](https://www.rfc-editor.org/rfc/rfc3339.html#appendix-A)).
+
+Examples include:
+
+The duration of 1 year and 6 months can be represented as:
+
+```
+P1Y6M
+```
+
+The using the optional minus sign, the negative duration of 9 months can be represented as:
+
+```
+-P9M
+```
+
+In XML Schema this is defined by [dayTimeDuration](https://www.w3.org/TR/xmlschema11-2/#dayTimeDuration), which is a restriction on the built-in type [duration](https://www.w3.org/TR/xmlschema11-2/#duration) as follows:
+
+```XML
+<xs:simpleType name="YearMonthDurationDatatype">
+  <xs:restriction base="xs:duration">
+    <xs:pattern value="-?P([0-9]+Y([0-9]+M)?)|[0-9]+M"/>
+  </xs:restriction>
+</xs:simpleType>
+```
+
+In JSON Schema, this is represented as:
+
+```JSON
+{
+  "type": "string",
+  "format": "duration",
+  "pattern": "^-?P([0-9]+Y([0-9]+M)?)|[0-9]+M$"
+}
+```
+
+
+## Markup Data Types
+
+Structured prose text is designed to map cleanly to equivalent subsets of HTML and Markdown. This allows HTML-like markup to be incorporated in Metaschema XML-based content using an element set maintained in the Metaschema namespace. This HTML-equivalent element set is not intended to be treated directly as HTML, but to be readily and transparently converted to HTML (or other presentational formats) as needed. Similarly, Metaschema uses a subset of Markdown for use in Metaschema JSON- and YAML-based content. A mapping is supported between the HTML-like element set and the Markdown syntax, which supports transparent and lossless bidirectional mapping between both markup representations.
+
+The HTML-like syntax supports:
+
+- HTML paragraphs (`<p>`), headers (`<h1>`-`<h6>`), tables (`<table>`), preformatted text (`<pre>`), code blocks (`<code>`), block quotes (`<blockquote>`), and ordered and unordered lists (`<ol>` and `<ul>`.)
+
+- Within paragraphs or text content: anchors (`<a>`), images (`<img>`), strong text (`<strong>` and `<b>`, normalized as `<strong>`), emphasis (`<em>` and `<i>`, normalized as `<em>`), superscript (`<sup>`), subscript (`<sub>`), and quote (`<q>`).
+
+In remarks below and throughout this documentation, this element set may be referred to as "prose content" or "prose". This tag set (and the Markdown equivalent) is defined as a data type module.
+
+Some tag attributes are also supported.
+
+- Anchors (`<a>`) require use of the `href` attribute and also allow the `title` attribute.
+- Images (`<img>`) require use of the `src` attribute and also allow the `alt` and `title` attributes.
+- Table cells  (`<th>` and `<td>`) allow the `align` attribute.
+
+Note that elements such as `<div>`, `<span>`, `<section>` and `<aside>`, used in HTML to provide structure, are *not permitted*. Instead, structures should be represented using specific model elements (or objects in JSON) such as `part`, which can include prose.
+
+In addition, there are contexts where prose usage may be further constrained by specific applications.
+
+The Markdown syntax is based on [CommonMark](https://commonmark.org/), which also defines the translation of Markdown to HTML. When in doubt about Markdown features and syntax, we look to CommonMark for guidance, largely because it is more rigorously tested than many other forms of Markdown.
+
+All CommonMark features are supported, except:
+
+- Link references - i.e. `[text][id] [id]: http://b.org/ "title"`
+
+### markup-line
+
+The following table describes the equivalent constructs in HTML and Markdown used within the `markup-line` data type.
+
+| Markup Type | HTML | Markdown |
+|:--- |:--- |:--- |
+| Emphasis (preferred) | `<em>text</em>` | `*text*`
+| Emphasis | `<i>text</i>` | `*text*`
+| Important Text (preferred) | `<strong>text</strong>` | `**text**`
+| Important Text | `<b>text</b>` | `**text**`
+| Inline code | `<code>text</code>` | `` `text` ``
+| Quoted Text | `<q>text</q>` | `"text"`
+| Subscript Text | `<sub>text</sub>` | `~text~`
+| Superscript Text | `<sup>text</sup>` | `^text^`
+| Image | `<img alt="alt text" src="url" title="title text"/>` | `![alt text](url "title text")`
+| Link | `<a href="url">text</a>` | `[text](*url*)`
+
+Note: Markdown does not have an equivalent of the HTML `<i>` and `<b>` tags, which indicate italics and bold respectively. These concepts are mapped in markup text to `<em>` and `<strong>` respectively (see [CommonMark](https://spec.commonmark.org/0.29/#emphasis-and-strong-emphasis)), which render equivalently in browsers, but do not have exactly the same semantics. While this mapping is imperfect, it represents the common uses of these HTML tags.
+
+#### Parameter Insertion
+
+The Metaschema model allows object references to be referenced and injected into prose text.
+
+Reference injection is handled using the `<insert>` tag, where you must provide its `type` and the identifier reference with `id-ref`:
+
+```html
+This implements <insert type="param" id-ref="pm-9_prm_1"/> as required to address organizational changes.
+```
+
+The same string in Markdown is represented as follows:
+
+```markdown
+This implements {{ insert: param, pm-9_prm_1 }} as required to address organizational changes.
+```
+
+#### Specialized Character Mapping
+
+The following characters have special handling in their HTML and/or Markdown forms.
+
+| Character                                      | XML HTML            | (plain) Markdown | Markdown in JSON | Markdown in YAML |
+| ---                                            | ---                 | ---              | ---              | ---              |
+| `&` (ampersand)                                | `&amp;`             | `&`              | `&`              | `&`              |
+| `<` (less-than sign or left angle bracket)     | `&lt;`              | `<`              | `<`              | `<`              |
+| `>` (greater-than sign or right angle bracket) | `>` **or** `&gt;`   | `>`              | `>`              | `>`              |
+| `"` (straight double quotation mark)           | `"` **or** `&quot;` | `"`              | `\\"`            | `"` **or** `\\"` |
+| `'` (straight apostrophe)                      | `'` **or** `&apos;` | `'`              | `'`              | `'` **or** `\\'` |
+| `*` (asterisk)                                 | `*`                 | `\*`             | `\\*`            | `\\*`            |
+| `` ` `` (grave accent or back tick mark)       | `` ` ``             | `` \` ``         | `` \\` ``        | `` \\` ``        |
+| `~` (tilde)                                    | `~`                 | `\~`             | `\\~`            | `\\~`            |
+| `^` (caret)                                    | `^`                 | `\^`             | `\\^`            | `\\^`            |
+
+While the characters ``*`~^`` are valid for use unescaped in JSON strings and YAML double quoted strings, these characters have special meaning in Markdown markup. As a result, when these characters appear as literals in a Markdown representation, they must be escaped to avoid them being parsed as Markdown to indicate formatting. The escaped representation indicates these characters are to be represented as characters, not markup, when the Markdown is mapped to HTML.
+
+Because the character `\` (back slash or reverse solidus) must be escaped in JSON, note that those characters that require a back slash to escape them in Markdown, such as `*` (appearing as `\*`), must be *double escaped* (as `\\*`) to represent the escaped character in JSON or YAML. In conversion, the JSON or YAML processor reduces these to the simple escaped form, again permitting the Markdown processor to recognize them as character contents, not markup.
+
+Since these characters are not markup delimiters in XML, they are safe to use there without special handling. The XML open markup delimiters `<` and `&`, when appearing in XML contents, must as always be escaped as named entities or numeric character references, if they are to be read as literal characters not markup.
+
+### markup-multiline
+
+All constructs supported by the [markup-line](#markup-line) data type are also supported by the `markup-multiline` data type, when appearing within a header (`<h1>`-`<h6>`), paragraph (`<p>`), list item (`<li>`) or table cell (`<th>` or `<td>`).
+
+The following additional constructs are also supported. Note that the syntax for these elements must appear on their own lines (i.e., with additional line feeds as delimiters), as is usual in Markdown.
+
+| Markup Type | HTML | Markdown |
+|:--- |:--- |:--- |
+| Heading: Level 1 | `<h1>text</h1>` | `# text`
+| Heading: Level 2 | `<h2>text</h2>` | `## text`
+| Heading: Level 3 | `<h3>text</h3>` | `### text`
+| Heading: Level 4 | `<h4>text</h4>` | `#### text`
+| Heading: Level 5 | `<h5>text</h5>` | `##### text`
+| Heading: Level 6 | `<h6>text</h6>` | `###### text`
+| Preformatted Text | `<pre>text</pre>` | <code>\`\`\`</code><br/><code>text</code><br/><code>\`\`\`</code>
+| Ordered List, with a single item | `<ol><li>text</li></ol>` | `1. text`
+| Unordered List with single item | `<ul><li>text</li></ul>` | `- text`
+| Blockquote | `<blockquote>text</blockquote>` | `> text`
+
+#### Paragraphs
+
+Additionally, the use of `<p>` tags in HTML is mapped to Markdown as two double, escaped newlines within a JSON or YAML string (i.e., "\\n\\n"). This allows Markdown text to be split into paragraphs when this data type is used.
+
+#### Tables
+
+Tables are also supported by `markup-multiline` which are mapped from Markdown to HTML as follows:
+
+- The first row in a Markdown table is considered a header row, with each cell mapped as a `<th>`.
+- The alignment formatting (second) row of the Markdown table is used to drive cell alignment using `<th align="value">` and `<td align="value">` in HTML.
+- Each remaining row is mapped as a cell using the `<td>` tag.
+- HTML `colspan` and `rowspan` are not supported by Markdown, and so are excluded from use.
+
+Simple tables are mainly supported due to the prevalence of tables in legacy data sets. However, producers of Metaschema data should note that when they have tabular information, these are frequently semantic structures or matrices that can be described directly in model-based structures as named parts and properties or as parts, sub-parts and paragraphs. This ensures that their nominal or represented semantics are accessible for processing when this information would be lost in plain table cells. Table markup should be used only as a fallback option when stronger semantic labeling is not possible.
+
+Tables are mapped from HTML to Markdown as follows:
+
+* Only a single header row `<tr><th>` is supported. This row is mapped to the Markdown table header, with header cells preceded, delimited, and terminated by `|`.
+* The second row is given as a sequence of `---`, as many as the table has columns, delimited by single `|`. In Markdown, a simple syntax here can be used to indicate the alignment of cells.
+* Each subsequent row is mapped to the Markdown table rows, with cells preceded, delimited, and terminated by `|`.
+
+For example:
+
+The following HTML table:
+
+```html
+<table>
+  <tr><th align="center">Col A</th><th align="center">Col B</th></tr>
+  <tr><td align="center">Have some of</td><td align="center">Try all of</td></tr>
+</table>
+```
+
+Is mapped to the Markdown table:
+
+```markdown
+| Col A | Col B |
+| --- | --- |
+| Have some of | Try all of |
+```
+
+#### Line feeds in Markdown
+
+Additionally, line feed (LF) characters must be escaped as `\n` when appearing in string contents in JSON and (depending on placement) in YAML. In Markdown, the line feed is used to delimit paragraphs and other block elements, represented using markup (tagging) in the XML version. When transcribed into JSON, these LF characters must also appear as `\n`.


### PR DESCRIPTION
# Committer Notes

This PR adds support  for prefix to namespace bindings for use in Metapath for supporting multiple models and Metapath types and functions with colliding names.

This PR will:

- Allow [qualified names](https://www.w3.org/TR/xpath-31/#dt-expanded-qname) to be used that reference a namespace URI by prefix. This is needed to 1) support the composition of models that have naming conflicts, and 2) support data types, functions and variables declared in user defined namespaces.
- Provide a path for implementations to support [inline Metapath functions](https://www.w3.org/TR/xpath-31/#id-inline-func) to be declared and used in user defined namespaces.

This PR builds on PR #659 and #570, which should be merged first.

### All Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/metaschema/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/metaschema/pulls) for the same update/change?
- [x] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all website](https://pages.nist.gov/metaschema) and readme documentation affected by the changes you made? Changes to the website can be made in the website/content directory of your branch.
